### PR TITLE
add notebooknodeexplorer shortcut copy paste

### DIFF
--- a/src/core/coreconfig.h
+++ b/src/core/coreconfig.h
@@ -69,6 +69,8 @@ namespace vnotex
             MoveOneSplitRight,
             OpenLastClosedFile,
             UnitedEntry,
+            Copy,
+            Paste,
             MaxShortcut
         };
         Q_ENUM(Shortcut)

--- a/src/data/core/vnotex.json
+++ b/src/data/core/vnotex.json
@@ -60,7 +60,9 @@
             "MoveOneSplitUp" : "Ctrl+G, Shift+K",
             "MoveOneSplitRight" : "Ctrl+G, Shift+L",
             "OpenLastClosedFile" : "Ctrl+Shift+T",
-            "UnitedEntry" : "Ctrl+G, G"
+            "UnitedEntry" : "Ctrl+G, G",
+            "Copy" : "Ctrl+C",
+            "Paste" : "Ctrl+V"
         },
         "file_type_suffixes" : [
             {

--- a/src/widgets/notebooknodeexplorer.cpp
+++ b/src/widgets/notebooknodeexplorer.cpp
@@ -2164,7 +2164,7 @@ void NotebookNodeExplorer::addOpenWithMenu(QMenu *p_menu, bool p_master)
 }
 
 // shortcut auxiliary, it can also be used to determine the browser
-bool NotebookNodeExplorer::isActionFromMaster()
+bool NotebookNodeExplorer::isActionFromMaster() const
 {
     if (!isCombinedExploreMode()) {
         return m_masterExplorer->hasFocus();

--- a/src/widgets/notebooknodeexplorer.cpp
+++ b/src/widgets/notebooknodeexplorer.cpp
@@ -2163,6 +2163,15 @@ void NotebookNodeExplorer::addOpenWithMenu(QMenu *p_menu, bool p_master)
                        });
 }
 
+// shortcut auxiliary, it can also be used to determine the browser
+bool NotebookNodeExplorer::isActionFromMaster()
+{
+    if (!isCombinedExploreMode()) {
+        return m_masterExplorer->hasFocus();
+    }
+    return false;
+}
+
 void NotebookNodeExplorer::setupShortcuts()
 {
     const auto &coreConfig = ConfigMgr::getInst().getCoreConfig();
@@ -2173,11 +2182,7 @@ void NotebookNodeExplorer::setupShortcuts()
         if (shortcut) {
             connect(shortcut, &QShortcut::activated,
                     this, [this]() {
-                        bool isMaster = true;
-                        if (!isCombinedExploreMode()) {
-                            isMaster = m_masterExplorer->hasFocus();
-                        }
-                        openSelectedNodesWithProgram(QString(), isMaster);
+                        openSelectedNodesWithProgram(QString(), isActionFromMaster());
                     });
         }
     }
@@ -2188,9 +2193,8 @@ void NotebookNodeExplorer::setupShortcuts()
         if (shortcut) {
             connect(shortcut, &QShortcut::activated,
                     this, [this]() {
-                        copySelectedNodes(false, false);
+                        copySelectedNodes(false, isActionFromMaster());
                     });
-
         }
     }
 
@@ -2199,9 +2203,7 @@ void NotebookNodeExplorer::setupShortcuts()
         auto shortcut = WidgetUtils::createShortcut(coreConfig.getShortcut(CoreConfig::Paste), this);
         if (shortcut) {
             connect(shortcut, &QShortcut::activated,
-                    this, [this]() {
-                        pasteNodesFromClipboard();
-                    });
+                    this, &NotebookNodeExplorer::pasteNodesFromClipboard);
         }
     }
 

--- a/src/widgets/notebooknodeexplorer.cpp
+++ b/src/widgets/notebooknodeexplorer.cpp
@@ -2182,6 +2182,29 @@ void NotebookNodeExplorer::setupShortcuts()
         }
     }
 
+    // Copy
+    {
+        auto shortcut = WidgetUtils::createShortcut(coreConfig.getShortcut(CoreConfig::Copy), this);
+        if (shortcut) {
+            connect(shortcut, &QShortcut::activated,
+                    this, [this]() {
+                        copySelectedNodes(false, false);
+                    });
+
+        }
+    }
+
+    // Paste
+    {
+        auto shortcut = WidgetUtils::createShortcut(coreConfig.getShortcut(CoreConfig::Paste), this);
+        if (shortcut) {
+            connect(shortcut, &QShortcut::activated,
+                    this, [this]() {
+                        pasteNodesFromClipboard();
+                    });
+        }
+    }
+
     const auto &sessionConfig = ConfigMgr::getInst().getSessionConfig();
     for (const auto &pro : sessionConfig.getExternalPrograms()) {
         auto shortcut = WidgetUtils::createShortcut(pro.m_shortcut, this);

--- a/src/widgets/notebooknodeexplorer.cpp
+++ b/src/widgets/notebooknodeexplorer.cpp
@@ -2169,7 +2169,7 @@ bool NotebookNodeExplorer::isActionFromMaster() const
     if (!isCombinedExploreMode()) {
         return m_masterExplorer->hasFocus();
     }
-    return false;
+    return true;
 }
 
 void NotebookNodeExplorer::setupShortcuts()

--- a/src/widgets/notebooknodeexplorer.cpp
+++ b/src/widgets/notebooknodeexplorer.cpp
@@ -2163,7 +2163,7 @@ void NotebookNodeExplorer::addOpenWithMenu(QMenu *p_menu, bool p_master)
                        });
 }
 
-// shortcut auxiliary, it can also be used to determine the browser
+// Shortcut auxiliary, it can also be used to determine the browser.
 bool NotebookNodeExplorer::isActionFromMaster() const
 {
     if (!isCombinedExploreMode()) {

--- a/src/widgets/notebooknodeexplorer.h
+++ b/src/widgets/notebooknodeexplorer.h
@@ -176,6 +176,8 @@ namespace vnotex
 
         void setupUI();
 
+        bool isActionFromMaster();
+
         void setupShortcuts();
 
         void setupMasterExplorer(QWidget *p_parent = nullptr);

--- a/src/widgets/notebooknodeexplorer.h
+++ b/src/widgets/notebooknodeexplorer.h
@@ -176,7 +176,7 @@ namespace vnotex
 
         void setupUI();
 
-        bool isActionFromMaster();
+        bool isActionFromMaster() const;
 
         void setupShortcuts();
 


### PR DESCRIPTION
Add notebooknodeexplorer global shortcut

In `NotebookNodeExplorer::setupShortcuts` impl

- Copy
- Paste

---

But I don't know what the second false means. `copySelectedNodes`