### PR TITLE
add notebooknodeexplorer shortcut new note folder and toolbar

### DIFF
--- a/src/core/coreconfig.h
+++ b/src/core/coreconfig.h
@@ -22,6 +22,7 @@ namespace vnotex
             ExpandContentArea,
             Settings,
             NewNote,
+            NewFolder,
             CloseTab,
             CloseOtherTabs,
             CloseTabsToTheRight,

--- a/src/data/core/vnotex.json
+++ b/src/data/core/vnotex.json
@@ -14,6 +14,7 @@
             "ExpandContentArea" : "Ctrl+G, E",
             "Settings" : "Ctrl+Alt+P",
             "NewNote" : "Ctrl+Alt+N",
+            "NewFolder" : "Ctrl+Alt+S",
             "CloseTab" : "Ctrl+G, X",
             "CloseOtherTabs" : "",
             "CloseTabsToTheRight" : "",

--- a/src/widgets/notebooknodeexplorer.cpp
+++ b/src/widgets/notebooknodeexplorer.cpp
@@ -1071,6 +1071,7 @@ QAction *NotebookNodeExplorer::createAction(Action p_act, QObject *p_parent, boo
                 this, []() {
                     emit VNoteX::getInst().newNoteRequested();
                 });
+        WidgetUtils::addActionShortcutText(act, coreConfig.getShortcut(CoreConfig::NewNote));
         break;
 
     case Action::NewFolder:
@@ -1081,6 +1082,7 @@ QAction *NotebookNodeExplorer::createAction(Action p_act, QObject *p_parent, boo
                 this, []() {
                     emit VNoteX::getInst().newFolderRequested();
                 });
+        WidgetUtils::addActionShortcutText(act, coreConfig.getShortcut(CoreConfig::NewFolder));
         break;
 
     case Action::Properties:

--- a/src/widgets/toolbarhelper.cpp
+++ b/src/widgets/toolbarhelper.cpp
@@ -134,12 +134,14 @@ QToolBar *ToolBarHelper::setupFileToolBar(MainWindow *p_win, QToolBar *p_toolBar
         newBtn->setText(MainWindow::tr("New Note"));
 
         // New folder.
-        newMenu->addAction(generateIcon("new_folder.svg"),
-                           MainWindow::tr("New Folder"),
-                           newMenu,
-                           []() {
-                               emit VNoteX::getInst().newFolderRequested();
-                           });
+        auto newFolderAct = newMenu->addAction(generateIcon("new_folder.svg"),
+                                               MainWindow::tr("New Folder"),
+                                               newMenu,
+                                               []() {
+                                                   emit VNoteX::getInst().newFolderRequested();
+                                               });
+        WidgetUtils::addActionShortcut(newFolderAct,
+                                       coreConfig.getShortcut(CoreConfig::Shortcut::NewFolder));
 
         newMenu->addSeparator();
 


### PR DESCRIPTION
Add notebooknodeexplorer and toolbarhelper global shortcut 

In `NotebookNodeExplorer::setupShortcuts` and  `ToolBarHelper::setupFileToolBar` impl 

- new note
- new folder