### PR TITLE
fix shortcut copy conflict

### DIFF
--- a/src/widgets/notebooknodeexplorer.cpp
+++ b/src/widgets/notebooknodeexplorer.cpp
@@ -2180,7 +2180,7 @@ void NotebookNodeExplorer::setupShortcuts()
 
     // Copy
     {
-        auto shortcut = WidgetUtils::createShortcut(coreConfig.getShortcut(CoreConfig::Copy), this);
+        auto shortcut = WidgetUtils::createShortcut(coreConfig.getShortcut(CoreConfig::Copy), this, Qt::WidgetWithChildrenShortcut);
         if (shortcut) {
             connect(shortcut, &QShortcut::activated,
                     this, [this]() {


### PR DESCRIPTION
NotebookNodeExplorer note copy with Text copy conflict.

To `Copy` to add `WidgetWithChildrenShortcut` conflict resolution.