### PR TITLE
feature/add_custom_icons

### DIFF
--- a/src/core/theme.cpp
+++ b/src/core/theme.cpp
@@ -443,7 +443,7 @@ QString Theme::getMarkdownEditorHighlightTheme() const
 
 bool Theme::getIconMonochrome() const
 {
-    return this->m_metadata.m_IconMonochrome;
+    return m_metadata.m_IconMonochrome;
 }
 
 QString Theme::name() const

--- a/src/core/theme.cpp
+++ b/src/core/theme.cpp
@@ -86,6 +86,7 @@ Theme::Metadata Theme::readMetadata(const Palette &p_obj)
     data.m_revision = metaObj[QStringLiteral("revision")].toInt();
     data.m_editorHighlightTheme = metaObj[QStringLiteral("editor-highlight-theme")].toString();
     data.m_markdownEditorHighlightTheme = metaObj[QStringLiteral("markdown-editor-highlight-theme")].toString();
+    data.m_IconMonochrome = metaObj[QStringLiteral("icon-monochrome")].toBool();
 
     return data;
 }
@@ -408,6 +409,8 @@ QString Theme::getFileName(File p_fileType)
         return QStringLiteral("markdown-editor-highlight.theme");
     case File::Cover:
         return QStringLiteral("cover.png");
+    case File::Icon:
+        return QStringLiteral("icons");
     default:
         Q_ASSERT(false);
         return "";
@@ -436,6 +439,11 @@ QString Theme::getMarkdownEditorHighlightTheme() const
     }
 
     return getEditorHighlightTheme();
+}
+
+bool Theme::getIconMonochrome() const
+{
+    return this->m_metadata.m_IconMonochrome;
 }
 
 QString Theme::name() const

--- a/src/core/theme.h
+++ b/src/core/theme.h
@@ -28,7 +28,8 @@ namespace vnotex
             EditorHighlightStyle,
             MarkdownEditorHighlightStyle,
             Cover,
-            Max
+            Max,
+            Icon
         };
 
         QString fetchQtStyleSheet() const;
@@ -43,6 +44,8 @@ namespace vnotex
 
         // Return the file path of the theme or just the theme name.
         QString getMarkdownEditorHighlightTheme() const;
+
+        bool getIconMonochrome() const;
 
         QString name() const;
 
@@ -69,6 +72,10 @@ namespace vnotex
             // If not specified, will use m_editorHighlightTheme.
             // Valid only when KSyntaxCodeBlockHighlighter is used.
             QString m_markdownEditorHighlightTheme;
+
+            // Whether the icon of the current theme uses monochrome.
+            // default is monochrome.
+            bool m_IconMonochrome = true;
         };
 
         typedef QJsonObject Palette;

--- a/src/core/theme.h
+++ b/src/core/theme.h
@@ -28,8 +28,8 @@ namespace vnotex
             EditorHighlightStyle,
             MarkdownEditorHighlightStyle,
             Cover,
-            Max,
-            Icon
+            Icon,
+            Max
         };
 
         QString fetchQtStyleSheet() const;
@@ -74,7 +74,7 @@ namespace vnotex
             QString m_markdownEditorHighlightTheme;
 
             // Whether the icon of the current theme uses monochrome.
-            // default is monochrome.
+            // Default is monochrome.
             bool m_IconMonochrome = true;
         };
 

--- a/src/core/thememgr.cpp
+++ b/src/core/thememgr.cpp
@@ -39,8 +39,7 @@ QString ThemeMgr::getIconFile(const QString &p_icon) const
 
     // If there is an ICONS folder in the theme configuration, use the custom ICONS from it.
     QString customIcon = getFile(Theme::File::Icon) + "/" + p_icon;
-    QFile customIconFile(customIcon);
-    if (customIconFile.exists()) {
+    if (QFile::exists(customIcon)) {
         return customIcon;
     } else {
         return ":/vnotex/data/core/icons/" + p_icon;
@@ -93,7 +92,6 @@ const Theme &ThemeMgr::getCurrentTheme() const
 void ThemeMgr::loadCurrentTheme(const QString &p_themeName)
 {
     auto themeFolder = findThemeFolder(p_themeName);
-
     if (themeFolder.isNull()) {
         qWarning() << "failed to locate theme" << p_themeName;
     } else {

--- a/src/core/thememgr.cpp
+++ b/src/core/thememgr.cpp
@@ -10,6 +10,7 @@
 #include <vtextedit/vtexteditor.h>
 #include "configmgr.h"
 #include "coreconfig.h"
+#include "theme.h"
 
 using namespace vnotex;
 
@@ -37,10 +38,10 @@ QString ThemeMgr::getIconFile(const QString &p_icon) const
     }
 
     // If there is an ICONS folder in the theme configuration, use the custom ICONS from it.
-    QString customIcons = this->customIconsPath + p_icon;
-    QFile iconsFile(customIcons);
-    if (iconsFile.exists()) {
-        return customIcons;
+    QString customIcon = getFile(Theme::File::Icon) + "/" + p_icon;
+    QFile customIconFile(customIcon);
+    if (customIconFile.exists()) {
+        return customIcon;
     } else {
         return ":/vnotex/data/core/icons/" + p_icon;
     }
@@ -92,12 +93,6 @@ const Theme &ThemeMgr::getCurrentTheme() const
 void ThemeMgr::loadCurrentTheme(const QString &p_themeName)
 {
     auto themeFolder = findThemeFolder(p_themeName);
-
-    QString customIconsPath = themeFolder + "/icons/";
-    QDir customIconsDir(customIconsPath);
-    if (customIconsDir.exists()) {
-        this->customIconsPath = customIconsPath;
-    }
 
     if (themeFolder.isNull()) {
         qWarning() << "failed to locate theme" << p_themeName;
@@ -184,6 +179,11 @@ QString ThemeMgr::getEditorHighlightTheme() const
 QString ThemeMgr::getMarkdownEditorHighlightTheme() const
 {
     return m_currentTheme->getMarkdownEditorHighlightTheme();
+}
+
+bool ThemeMgr::getIconMonochrome() const
+{
+    return m_currentTheme->getIconMonochrome();
 }
 
 void ThemeMgr::addSyntaxHighlightingSearchPaths(const QStringList &p_paths)

--- a/src/core/thememgr.cpp
+++ b/src/core/thememgr.cpp
@@ -36,7 +36,14 @@ QString ThemeMgr::getIconFile(const QString &p_icon) const
         return p_icon;
     }
 
-    return ":/vnotex/data/core/icons/" + p_icon;
+    // If there is an ICONS folder in the theme configuration, use the custom ICONS from it.
+    QString customIcons = this->customIconsPath + p_icon;
+    QFile iconsFile(customIcons);
+    if (iconsFile.exists()) {
+        return customIcons;
+    } else {
+        return ":/vnotex/data/core/icons/" + p_icon;
+    }
 }
 
 void ThemeMgr::loadAvailableThemes()
@@ -85,6 +92,13 @@ const Theme &ThemeMgr::getCurrentTheme() const
 void ThemeMgr::loadCurrentTheme(const QString &p_themeName)
 {
     auto themeFolder = findThemeFolder(p_themeName);
+
+    QString customIconsPath = themeFolder + "/icons/";
+    QDir customIconsDir(customIconsPath);
+    if (customIconsDir.exists()) {
+        this->customIconsPath = customIconsPath;
+    }
+
     if (themeFolder.isNull()) {
         qWarning() << "failed to locate theme" << p_themeName;
     } else {

--- a/src/core/thememgr.h
+++ b/src/core/thememgr.h
@@ -44,6 +44,8 @@ namespace vnotex
 
         QString getFile(Theme::File p_fileType) const;
 
+        QString customIconsPath;
+
         // Return the file path of the theme or just the theme name.
         QString getEditorHighlightTheme() const;
 

--- a/src/core/thememgr.h
+++ b/src/core/thememgr.h
@@ -44,12 +44,12 @@ namespace vnotex
 
         QString getFile(Theme::File p_fileType) const;
 
-        QString customIconsPath;
-
         // Return the file path of the theme or just the theme name.
         QString getEditorHighlightTheme() const;
 
         QString getMarkdownEditorHighlightTheme() const;
+
+        bool getIconMonochrome() const;
 
         const QColor &getBaseBackground() const;
         void setBaseBackground(const QColor &p_bg);

--- a/src/data/extra/themes/moonlight/palette.json
+++ b/src/data/extra/themes/moonlight/palette.json
@@ -10,7 +10,8 @@
         "markdown-editor-highlight-theme" : "Markdown Breeze Dark",
         "display_name" : "Moonlight",
         "//comment" : "Display name for different locales",
-        "display_name_zh_CN" : "月夜"
+        "display_name_zh_CN" : "月夜",
+        "icon-monochrome": false
     },
     "palette" : {
         "bg1_1" : "#07080d",

--- a/src/data/extra/themes/moonlight/palette.json
+++ b/src/data/extra/themes/moonlight/palette.json
@@ -11,7 +11,7 @@
         "display_name" : "Moonlight",
         "//comment" : "Display name for different locales",
         "display_name_zh_CN" : "月夜",
-        "icon-monochrome": false
+        "icon-monochrome": true
     },
     "palette" : {
         "bg1_1" : "#07080d",

--- a/src/data/extra/themes/native/palette.json
+++ b/src/data/extra/themes/native/palette.json
@@ -10,7 +10,8 @@
         "markdown-editor-highlight-theme" : "Markdown Default",
         "display_name" : "Native",
         "//comment" : "Display name for different locales",
-        "display_name_zh_CN" : "原素"
+        "display_name_zh_CN" : "原素",
+        "icon-monochrome": false
     },
     "base" : {
         "normal" : {

--- a/src/data/extra/themes/native/palette.json
+++ b/src/data/extra/themes/native/palette.json
@@ -11,7 +11,7 @@
         "display_name" : "Native",
         "//comment" : "Display name for different locales",
         "display_name_zh_CN" : "原素",
-        "icon-monochrome": false
+        "icon-monochrome": true
     },
     "base" : {
         "normal" : {

--- a/src/data/extra/themes/pure/palette.json
+++ b/src/data/extra/themes/pure/palette.json
@@ -11,7 +11,7 @@
         "display_name" : "Pure",
         "//comment" : "Display name for different locales",
         "display_name_zh_CN" : "纯净",
-        "icon-monochrome": false
+        "icon-monochrome": true
     },
     "palette" : {
         "bg3_0" : "#bbbbbb",

--- a/src/data/extra/themes/pure/palette.json
+++ b/src/data/extra/themes/pure/palette.json
@@ -10,7 +10,8 @@
         "markdown-editor-highlight-theme" : "Markdown Default",
         "display_name" : "Pure",
         "//comment" : "Display name for different locales",
-        "display_name_zh_CN" : "纯净"
+        "display_name_zh_CN" : "纯净",
+        "icon-monochrome": false
     },
     "palette" : {
         "bg3_0" : "#bbbbbb",

--- a/src/data/extra/themes/solarized-dark/palette.json
+++ b/src/data/extra/themes/solarized-dark/palette.json
@@ -11,7 +11,8 @@
         "display_name" : "Solarized-dark",
         "//comment" : "Display name for different locales",
         "display_name_zh_CN" : "Solarized-dark",
-        "author": "nriver"
+        "author": "nriver",
+        "icon-monochrome": false
     },
     "palette" : {
         "bg1_1" : "#002b36",

--- a/src/data/extra/themes/solarized-dark/palette.json
+++ b/src/data/extra/themes/solarized-dark/palette.json
@@ -12,7 +12,7 @@
         "//comment" : "Display name for different locales",
         "display_name_zh_CN" : "Solarized-dark",
         "author": "nriver",
-        "icon-monochrome": false
+        "icon-monochrome": true
     },
     "palette" : {
         "bg1_1" : "#002b36",

--- a/src/data/extra/themes/solarized-light/palette.json
+++ b/src/data/extra/themes/solarized-light/palette.json
@@ -11,7 +11,8 @@
         "display_name" : "Solarized-light",
         "//comment" : "Display name for different locales",
         "display_name_zh_CN" : "Solarized-light",
-        "author": "nriver"
+        "author": "nriver",
+        "icon-monochrome": false
     },
     "palette" : {
         "bg1_1" : "#FFFFF5",

--- a/src/data/extra/themes/solarized-light/palette.json
+++ b/src/data/extra/themes/solarized-light/palette.json
@@ -12,7 +12,7 @@
         "//comment" : "Display name for different locales",
         "display_name_zh_CN" : "Solarized-light",
         "author": "nriver",
-        "icon-monochrome": false
+        "icon-monochrome": true
     },
     "palette" : {
         "bg1_1" : "#FFFFF5",

--- a/src/data/extra/themes/vscode-dark/palette.json
+++ b/src/data/extra/themes/vscode-dark/palette.json
@@ -11,7 +11,7 @@
         "display_name" : "VSCode-dark",
         "//comment" : "Display name for different locales",
         "display_name_zh_CN" : "VSCode-深色",
-        "icon-monochrome": false
+        "icon-monochrome": true
     },
     "palette" : {
         "bg1_1" : "#07080d",

--- a/src/data/extra/themes/vscode-dark/palette.json
+++ b/src/data/extra/themes/vscode-dark/palette.json
@@ -10,7 +10,8 @@
         "markdown-editor-highlight-theme" : "vscode-dark",
         "display_name" : "VSCode-dark",
         "//comment" : "Display name for different locales",
-        "display_name_zh_CN" : "VSCode-深色"
+        "display_name_zh_CN" : "VSCode-深色",
+        "icon-monochrome": false
     },
     "palette" : {
         "bg1_1" : "#07080d",

--- a/src/utils/iconutils.cpp
+++ b/src/utils/iconutils.cpp
@@ -21,7 +21,8 @@ QIcon IconUtils::fetchIcon(const QString &p_iconFile,
                            qreal p_angle)
 {
     const auto suffix = QFileInfo(p_iconFile).suffix().toLower().toStdString();
-    if (p_overriddenColors.isEmpty() || suffix != "svg") {
+    if ((p_overriddenColors.isEmpty() || suffix != "svg")
+            && !VNoteX::getInst().getThemeMgr().getIconMonochrome()) {
         return QIcon(p_iconFile);
     }
 

--- a/src/utils/iconutils.cpp
+++ b/src/utils/iconutils.cpp
@@ -50,7 +50,7 @@ QIcon IconUtils::fetchIcon(const QString &p_iconFile, const QString &p_overridde
     QVector<OverriddenColor> colors;
     const auto &themeMgr = VNoteX::getInst().getThemeMgr();
 
-    if (!p_overriddenForeground.isEmpty() && themeMgr.customIconsPath.isEmpty()) {
+    if (!p_overriddenForeground.isEmpty() && themeMgr.getIconMonochrome()) {
         colors.push_back(OverriddenColor(p_overriddenForeground, QIcon::Normal, QIcon::Off));
     }
 

--- a/src/utils/iconutils.cpp
+++ b/src/utils/iconutils.cpp
@@ -6,6 +6,8 @@
 #include <QPainter>
 #include <QDebug>
 
+#include <core/vnotex.h>
+
 #include "fileutils.h"
 
 using namespace vnotex;
@@ -46,7 +48,9 @@ QIcon IconUtils::fetchIcon(const QString &p_iconFile,
 QIcon IconUtils::fetchIcon(const QString &p_iconFile, const QString &p_overriddenForeground)
 {
     QVector<OverriddenColor> colors;
-    if (!p_overriddenForeground.isEmpty()) {
+    const auto &themeMgr = VNoteX::getInst().getThemeMgr();
+
+    if (!p_overriddenForeground.isEmpty() && themeMgr.customIconsPath.isEmpty()) {
         colors.push_back(OverriddenColor(p_overriddenForeground, QIcon::Normal, QIcon::Off));
     }
 

--- a/src/widgets/dockwidgethelper.cpp
+++ b/src/widgets/dockwidgethelper.cpp
@@ -512,16 +512,20 @@ QVector<void *> DockWidgetHelper::getVisibleNavigationItems()
 
 const QIcon &DockWidgetHelper::getDockIcon(DockIndex p_dockIndex)
 {
-    static const auto fg = VNoteX::getInst().getThemeMgr().paletteColor("widgets#mainwindow#dockwidget_tabbar#icon#fg");
-    static const auto selectedFg = VNoteX::getInst().getThemeMgr().paletteColor("widgets#mainwindow#dockwidget_tabbar#icon#selected#fg");
+    const auto &themeMgr = VNoteX::getInst().getThemeMgr();
+
+    static const auto fg = themeMgr.paletteColor("widgets#mainwindow#dockwidget_tabbar#icon#fg");
+    static const auto selectedFg = themeMgr.paletteColor("widgets#mainwindow#dockwidget_tabbar#icon#selected#fg");
 
     const auto area = m_mainWindow->dockWidgetArea(m_docks[p_dockIndex]);
     const int newAngle = rotationAngle(area);
     if (m_dockIcons[p_dockIndex].m_rotationAngle != newAngle && area != Qt::NoDockWidgetArea) {
         QVector<IconUtils::OverriddenColor> colors;
-        colors.push_back(IconUtils::OverriddenColor(fg, QIcon::Normal));
-        // FIXME: the Selected Mode is not used by the selected tab of a QTabBar.
-        colors.push_back(IconUtils::OverriddenColor(selectedFg, QIcon::Selected));
+        if (themeMgr.customIconsPath.isEmpty()) {
+            colors.push_back(IconUtils::OverriddenColor(fg, QIcon::Normal));
+            // FIXME: the Selected Mode is not used by the selected tab of a QTabBar.
+            colors.push_back(IconUtils::OverriddenColor(selectedFg, QIcon::Selected));
+        }
 
         auto iconFile = VNoteX::getInst().getThemeMgr().getIconFile(iconFileName(p_dockIndex));
         m_dockIcons[p_dockIndex].m_icon = IconUtils::fetchIcon(iconFile, colors, newAngle);

--- a/src/widgets/dockwidgethelper.cpp
+++ b/src/widgets/dockwidgethelper.cpp
@@ -521,7 +521,7 @@ const QIcon &DockWidgetHelper::getDockIcon(DockIndex p_dockIndex)
     const int newAngle = rotationAngle(area);
     if (m_dockIcons[p_dockIndex].m_rotationAngle != newAngle && area != Qt::NoDockWidgetArea) {
         QVector<IconUtils::OverriddenColor> colors;
-        if (themeMgr.customIconsPath.isEmpty()) {
+        if (themeMgr.getIconMonochrome()) {
             colors.push_back(IconUtils::OverriddenColor(fg, QIcon::Normal));
             // FIXME: the Selected Mode is not used by the selected tab of a QTabBar.
             colors.push_back(IconUtils::OverriddenColor(selectedFg, QIcon::Selected));

--- a/src/widgets/dockwidgethelper.cpp
+++ b/src/widgets/dockwidgethelper.cpp
@@ -512,20 +512,15 @@ QVector<void *> DockWidgetHelper::getVisibleNavigationItems()
 
 const QIcon &DockWidgetHelper::getDockIcon(DockIndex p_dockIndex)
 {
-    const auto &themeMgr = VNoteX::getInst().getThemeMgr();
-
-    static const auto fg = themeMgr.paletteColor("widgets#mainwindow#dockwidget_tabbar#icon#fg");
-    static const auto selectedFg = themeMgr.paletteColor("widgets#mainwindow#dockwidget_tabbar#icon#selected#fg");
-
+    static const auto fg = VNoteX::getInst().getThemeMgr().paletteColor("widgets#mainwindow#dockwidget_tabbar#icon#fg");
+    static const auto selectedFg = VNoteX::getInst().getThemeMgr().paletteColor("widgets#mainwindow#dockwidget_tabbar#icon#selected#fg");
     const auto area = m_mainWindow->dockWidgetArea(m_docks[p_dockIndex]);
     const int newAngle = rotationAngle(area);
     if (m_dockIcons[p_dockIndex].m_rotationAngle != newAngle && area != Qt::NoDockWidgetArea) {
         QVector<IconUtils::OverriddenColor> colors;
-        if (themeMgr.getIconMonochrome()) {
-            colors.push_back(IconUtils::OverriddenColor(fg, QIcon::Normal));
-            // FIXME: the Selected Mode is not used by the selected tab of a QTabBar.
-            colors.push_back(IconUtils::OverriddenColor(selectedFg, QIcon::Selected));
-        }
+        colors.push_back(IconUtils::OverriddenColor(fg, QIcon::Normal));
+        // FIXME: the Selected Mode is not used by the selected tab of a QTabBar.
+        colors.push_back(IconUtils::OverriddenColor(selectedFg, QIcon::Selected));
 
         auto iconFile = VNoteX::getInst().getThemeMgr().getIconFile(iconFileName(p_dockIndex));
         m_dockIcons[p_dockIndex].m_icon = IconUtils::fetchIcon(iconFile, colors, newAngle);

--- a/src/widgets/toolbarhelper.cpp
+++ b/src/widgets/toolbarhelper.cpp
@@ -421,7 +421,7 @@ QIcon ToolBarHelper::generateIcon(const QString &p_iconName)
 
     const auto &themeMgr = VNoteX::getInst().getThemeMgr();
 
-    if (colors.isEmpty() && themeMgr.getIconMonochrome()) {
+    if (colors.isEmpty()) {
         const auto fg = themeMgr.paletteColor(c_fgPalette);
         const auto disabledFg = themeMgr.paletteColor(c_disabledPalette);
 

--- a/src/widgets/toolbarhelper.cpp
+++ b/src/widgets/toolbarhelper.cpp
@@ -421,7 +421,7 @@ QIcon ToolBarHelper::generateIcon(const QString &p_iconName)
 
     const auto &themeMgr = VNoteX::getInst().getThemeMgr();
 
-    if (colors.isEmpty()) {
+    if (colors.isEmpty() && themeMgr.customIconsPath.isEmpty() ) {
         const auto fg = themeMgr.paletteColor(c_fgPalette);
         const auto disabledFg = themeMgr.paletteColor(c_disabledPalette);
 

--- a/src/widgets/toolbarhelper.cpp
+++ b/src/widgets/toolbarhelper.cpp
@@ -421,7 +421,7 @@ QIcon ToolBarHelper::generateIcon(const QString &p_iconName)
 
     const auto &themeMgr = VNoteX::getInst().getThemeMgr();
 
-    if (colors.isEmpty() && themeMgr.customIconsPath.isEmpty() ) {
+    if (colors.isEmpty() && themeMgr.getIconMonochrome()) {
         const auto fg = themeMgr.paletteColor(c_fgPalette);
         const auto disabledFg = themeMgr.paletteColor(c_disabledPalette);
 


### PR DESCRIPTION
Implement custom ICONS. 

Vnote on startup, the ICONS folder in the `theme` directory is loaded, and if there are images in it, they are loaded and used

- add `customIconsPath` var, Used to determine the existence of custom logic and to verify ICONS.
- modify `icons color push_back` logic, Add judgment between default ICONS and custom ICONS.