### PR TITLE
Fix export html/pdf problem in Qt 5.15.5

### DIFF
--- a/src/data/extra/web/js/prism.js
+++ b/src/data/extra/web/js/prism.js
@@ -99,7 +99,7 @@ class PrismRenderer extends VxWorker {
         let toolBarNodes = p_containerNode.querySelectorAll('div.code-toolbar > div.toolbar');
         for (let i = 0; i < toolBarNodes.length; ++i) {
             toolBarNodes[i].outerHTML = '';
-            delete toolBarNodes[i];
+            try { delete toolBarNodes[i]; } catch (err) {}
         }
     }
 }


### PR DESCRIPTION
maybe related https://github.com/vnotex/vnote/issues/1942   export PDF cpu 100%.

Qt 5.15.5 error log
```
Critical:(markdownviewer.js:103) Uncaught TypeError: Failed to delete an indexed property from 'NodeList': Index property deleter is not supported.
[520896:520896:0801/171207.286744:INFO:CONSOLE(103)] "Uncaught TypeError: Failed to delete an indexed property from 'NodeList': Index property deleter is not supported.", source: file:///home/henices/.local/share/VNote/VNote/web/js/prism.js (103)
```