### PR TITLE
Fix mermaid display problem in the editing state.

### DIFF
--- a/src/data/extra/web/js/graphpreviewer.js
+++ b/src/data/extra/web/js/graphpreviewer.js
@@ -188,7 +188,7 @@ class GraphPreviewer {
 
         if (p_svgNode.getAttribute('width').indexOf('%') != -1) {
             // Try maxWidth.
-            if (p_svgNode.style.maxWidth && p_svgNode.style.maxWidth.endsWith('px')) {
+            if (p_svgNode.style.maxWidth && p_svgNode.style.maxWidth.endsWith('px') && p_svgNode.style.maxWidth != "0px") {
                 p_svgNode.setAttribute('width', p_svgNode.style.maxWidth);
             } else {
                 // Set as window width.
@@ -220,10 +220,12 @@ class GraphPreviewer {
             return;
         }
 
-        if (p_svgNode.getAttribute('width').indexOf('%') == -1) {
+        let width = p_svgNode.getAttribute('width')
+        if (width && width.indexOf('%') == -1) {
             p_svgNode.width.baseVal.valueInSpecifiedUnits *= scaleFactor;
         }
-        if (p_svgNode.getAttribute('height').indexOf('%') == -1) {
+        let height = p_svgNode.getAttribute('height')
+        if (height && height.indexOf('%') == -1) {
             p_svgNode.height.baseVal.valueInSpecifiedUnits *= scaleFactor;
         }
     }

--- a/src/data/extra/web/js/svg-to-image.js
+++ b/src/data/extra/web/js/svg-to-image.js
@@ -60,7 +60,7 @@ class SvgToImage {
         let url = domUrl.createObjectURL(blob);
         this.loadImage(url, p_opt, function(err, img) {
             domUrl.revokeObjectURL(url);
-            if (err) {
+            if (err || SvgToImage.checkCanvasToDataURL(img) === null) {
                 // try again for Safari 8.0, using simple encodeURIComponent
                 // this will fail with DOM content but at least it works with SVG.
                 let url2 = 'data:image/svg+xml,' + encodeURIComponent(p_svg.join(''));
@@ -73,5 +73,20 @@ class SvgToImage {
 
     static getUrl() {
         return window.URL || window.webkitURL || window.mozURL || window.msURL;
+    }
+
+    static checkCanvasToDataURL(p_image) {
+        let canvas = document.createElement('canvas');
+        let ctx = canvas.getContext('2d');
+        canvas.height = p_image.height;
+        canvas.width = p_image.width;
+        ctx.drawImage(p_image, 0, 0);
+        let dataUrl = null;
+        try {
+            dataUrl = canvas.toDataURL();
+        } catch (err) {
+
+        }
+        return dataUrl
     }
 }


### PR DESCRIPTION
<img width="799" alt="image" src="https://user-images.githubusercontent.com/17684070/212633666-934638b1-5486-4268-b25e-80324a4bd0db.png">


Most of the demos provided by https://mermaid.live/ passed the test, except for Pie and Gantt. But these two seem to be bugs in the mermaid itself, which renders the viewbox width of the svg equal to 0.

<img width="920" alt="image" src="https://user-images.githubusercontent.com/17684070/212656926-826ad422-1f54-4d52-9bec-f81bdb95af6d.png">


For mindmap, additional work is required:
https://mermaid.js.org/syntax/mindmap.html
