### PR TITLE
fix/pdf_name_ascii

### DIFF
--- a/src/widgets/pdfviewwindow.cpp
+++ b/src/widgets/pdfviewwindow.cpp
@@ -119,7 +119,8 @@ void PdfViewWindow::syncEditorFromBuffer()
     auto buffer = getBuffer();
     if (buffer) {
         const auto url = PathUtils::pathToUrl(buffer->getContentPath());
-        const auto urlStr = url.toString(QUrl::EncodeSpaces);
+        // Solution to ASCII problems, like these file names with these symbols # + &.
+        const auto urlStr = QUrl::toPercentEncoding(url.toString(QUrl::EncodeSpaces));
         auto templateUrl = PathUtils::pathToUrl(HtmlTemplateHelper::getPdfViewerTemplatePath());
         templateUrl.setQuery("file=" + urlStr);
         m_viewer->setHtml(HtmlTemplateHelper::getPdfViewerTemplate(), templateUrl);

--- a/src/widgets/pdfviewwindow.cpp
+++ b/src/widgets/pdfviewwindow.cpp
@@ -120,7 +120,7 @@ void PdfViewWindow::syncEditorFromBuffer()
     if (buffer) {
         const auto url = PathUtils::pathToUrl(buffer->getContentPath());
         // Solution to ASCII problems, like these file names with these symbols # + &.
-        const auto urlStr = url.toString(QUrl::EncodeSpaces).toUtf8().toPercentEncoding();
+        const auto urlStr = QUrl::toPercentEncoding(url.toString(QUrl::FullyDecoded));
         auto templateUrl = PathUtils::pathToUrl(HtmlTemplateHelper::getPdfViewerTemplatePath());
         templateUrl.setQuery("file=" + urlStr);
         m_viewer->setHtml(HtmlTemplateHelper::getPdfViewerTemplate(), templateUrl);

--- a/src/widgets/pdfviewwindow.cpp
+++ b/src/widgets/pdfviewwindow.cpp
@@ -120,7 +120,7 @@ void PdfViewWindow::syncEditorFromBuffer()
     if (buffer) {
         const auto url = PathUtils::pathToUrl(buffer->getContentPath());
         // Solution to ASCII problems, like these file names with these symbols # + &.
-        const auto urlStr = QUrl::toPercentEncoding(url.toString(QUrl::EncodeSpaces));
+        const auto urlStr = url.toString(QUrl::EncodeSpaces).toUtf8().toPercentEncoding();
         auto templateUrl = PathUtils::pathToUrl(HtmlTemplateHelper::getPdfViewerTemplatePath());
         templateUrl.setQuery("file=" + urlStr);
         m_viewer->setHtml(HtmlTemplateHelper::getPdfViewerTemplate(), templateUrl);


### PR DESCRIPTION
If the pdf file name has symbols that the url needs to escape, there will be problems when passing to js and when actually reading the file.

For example:

```
Debug:(notebookdatabaseaccess.cpp:332) updated node 5239 8841029587366337895 "ansible-for-devops#.pdf" 4751
Debug:(pdfviewwindow.cpp:127) ---> QUrl("file:///Users/cdp/Library/Application Support/VNote/VNote/web/pdf.js/web/pdf-viewer-template.html?file=file:///Users/cdp/note/m/11_book/devops/ansible-for-devops%23.pdf")
Critical:(markdownviewer.js:2049) 缺少 PDF 文件。

PDF.js v3.1.81 (build: 0766898d5)
Message: Missing PDF "file:///Users/cdp/note/m/11_book/devops/ansible-for-devops#.pdf".
```

This fix is to forcibly convert all pdf url that need to be opened into ascii.