### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/src/core/buffer/buffer.cpp
+++ b/src/core/buffer/buffer.cpp
@@ -358,7 +358,7 @@ void Buffer::writeBackupFile()
 
 QString Buffer::generateBackupFileHead() const
 {
-    return QString("vnotex_backup_file %1|").arg(getContentPath());
+    return QStringLiteral("vnotex_backup_file %1|").arg(getContentPath());
 }
 
 void Buffer::checkBackupFileOfPreviousSession()
@@ -373,7 +373,7 @@ void Buffer::checkBackupFileOfPreviousSession()
     QDir backupDir(backupDirPath);
     QStringList backupFiles;
     {
-        const QString nameFilter = QString("%1*%2").arg(getName(), config.getBackupFileExtension());
+        const QString nameFilter = QStringLiteral("%1*%2").arg(getName(), config.getBackupFileExtension());
         backupFiles = backupDir.entryList(QStringList(nameFilter),
                                           QDir::Files | QDir::Hidden | QDir::NoSymLinks | QDir::NoDotAndDotDot);
     }

--- a/src/core/buffermgr.cpp
+++ b/src/core/buffermgr.cpp
@@ -75,7 +75,7 @@ void BufferMgr::open(Node *p_node, const QSharedPointer<FileOpenParameters> &p_p
     }
 
     if (!p_node->checkExists()) {
-        auto msg = QString("Failed to open node that does not exist (%1)").arg(p_node->fetchAbsolutePath());
+        auto msg = QStringLiteral("Failed to open node that does not exist (%1)").arg(p_node->fetchAbsolutePath());
         qWarning() << msg;
         VNoteX::getInst().showStatusMessageShort(msg);
         return;
@@ -133,7 +133,7 @@ void BufferMgr::open(const QString &p_filePath, const QSharedPointer<FileOpenPar
 
     QFileInfo finfo(p_filePath);
     if (!finfo.exists()) {
-        auto msg = QString("Failed to open file that does not exist (%1)").arg(p_filePath);
+        auto msg = QStringLiteral("Failed to open file that does not exist (%1)").arg(p_filePath);
         qWarning() << msg;
         VNoteX::getInst().showStatusMessageShort(msg);
         WidgetUtils::openUrlByDesktop(QUrl::fromUserInput(p_filePath));

--- a/src/core/clipboarddata.cpp
+++ b/src/core/clipboarddata.cpp
@@ -63,14 +63,14 @@ void ClipboardData::fromJson(const QJsonObject &p_jobj)
         || !p_jobj.contains(c_action)
         || !p_jobj.contains(c_data)) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("fail to parse ClipboardData from json (%1)").arg(p_jobj.keys().join(',')));
+                            QStringLiteral("fail to parse ClipboardData from json (%1)").arg(p_jobj.keys().join(',')));
         return;
     }
 
     auto idRet = stringToID(p_jobj[c_instanceId].toString());
     if (!idRet.first) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("fail to parse ClipboardData from json (%1)").arg(p_jobj.keys().join(',')));
+                            QStringLiteral("fail to parse ClipboardData from json (%1)").arg(p_jobj.keys().join(',')));
         return;
     }
     m_instanceId = idRet.second;
@@ -79,7 +79,7 @@ void ClipboardData::fromJson(const QJsonObject &p_jobj)
     m_action = intToAction(act);
     if (m_action == Action::Invalid) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("fail to parse ClipboardData from json (%1)").arg(p_jobj.keys().join(',')));
+                            QStringLiteral("fail to parse ClipboardData from json (%1)").arg(p_jobj.keys().join(',')));
         return;
     }
 

--- a/src/core/configmgr.cpp
+++ b/src/core/configmgr.cpp
@@ -195,7 +195,7 @@ bool ConfigMgr::checkAppConfig()
     bool ret = QResource::registerResource(extraRcc);
     if (!ret) {
         Exception::throwOne(Exception::Type::FailToReadFile,
-                            QString("failed to register resource file %1").arg(extraRcc));
+                            QStringLiteral("failed to register resource file %1").arg(extraRcc));
     }
     auto cleanup = qScopeGuard([extraRcc]() {
         QResource::unregisterResource(extraRcc);

--- a/src/core/exception.h
+++ b/src/core/exception.h
@@ -47,46 +47,46 @@ namespace vnotex
         {
             switch (p_type) {
             case Type::InvalidPath:
-                return QString("InvalidPath");
+                return QStringLiteral("InvalidPath");
 
             case Type::FailToCreateDir:
-                return QString("FailToCreateDir");
+                return QStringLiteral("FailToCreateDir");
 
             case Type::FailToWriteFile:
-                return QString("FailToWriteFile");
+                return QStringLiteral("FailToWriteFile");
 
             case Type::FailToReadFile:
-                return QString("FailToReadFile");
+                return QStringLiteral("FailToReadFile");
 
             case Type::FailToRenameFile:
-                return QString("FailToRenameFile");
+                return QStringLiteral("FailToRenameFile");
 
             case Type::FailToCopyFile:
-                return QString("FailToCopyFile");
+                return QStringLiteral("FailToCopyFile");
 
             case Type::FailToCopyDir:
-                return QString("FailToCopyDir");
+                return QStringLiteral("FailToCopyDir");
 
             case Type::FailToRemoveFile:
-                return QString("FailToRemoveFile");
+                return QStringLiteral("FailToRemoveFile");
 
             case Type::FailToRemoveDir:
-                return QString("FailToRemoveDir");
+                return QStringLiteral("FailToRemoveDir");
 
             case Type::FileMissingOnDisk:
-                return QString("FileMissingOnDisk");
+                return QStringLiteral("FileMissingOnDisk");
 
             case Type::EssentialFileMissing:
-                return QString("EssentialFileMissing");
+                return QStringLiteral("EssentialFileMissing");
 
             case Type::FileExistsOnCreate:
-                return QString("FileExistsOnCreate");
+                return QStringLiteral("FileExistsOnCreate");
 
             case Type::DirExistsOnCreate:
-                return QString("DirExistsOnCreate");
+                return QStringLiteral("DirExistsOnCreate");
 
             case Type::InvalidArgument:
-                return QString("InvalidArgument");
+                return QStringLiteral("InvalidArgument");
             }
 
             return QString::number(static_cast<int>(p_type));

--- a/src/core/htmltemplatehelper.cpp
+++ b/src/core/htmltemplatehelper.cpp
@@ -25,27 +25,27 @@ HtmlTemplateHelper::Template HtmlTemplateHelper::s_mindMapEditorTemplate;
 QString MarkdownWebGlobalOptions::toJavascriptObject() const
 {
     return QStringLiteral("window.vxOptions = {\n")
-           + QString("webPlantUml: %1,\n").arg(Utils::boolToString(m_webPlantUml))
-           + QString("plantUmlWebService: '%1',\n").arg(m_plantUmlWebService)
-           + QString("webGraphviz: %1,\n").arg(Utils::boolToString(m_webGraphviz))
-           + QString("mathJaxScript: '%1',\n").arg(m_mathJaxScript)
-           + QString("constrainImageWidthEnabled: %1,\n").arg(Utils::boolToString(m_constrainImageWidthEnabled))
-           + QString("imageAlignCenterEnabled: %1,\n").arg(Utils::boolToString(m_imageAlignCenterEnabled))
-           + QString("protectFromXss: %1,\n").arg(Utils::boolToString(m_protectFromXss))
-           + QString("htmlTagEnabled: %1,\n").arg(Utils::boolToString(m_htmlTagEnabled))
-           + QString("autoBreakEnabled: %1,\n").arg(Utils::boolToString(m_autoBreakEnabled))
-           + QString("linkifyEnabled: %1,\n").arg(Utils::boolToString(m_linkifyEnabled))
-           + QString("indentFirstLineEnabled: %1,\n").arg(Utils::boolToString(m_indentFirstLineEnabled))
-           + QString("codeBlockLineNumberEnabled: %1,\n").arg(Utils::boolToString(m_codeBlockLineNumberEnabled))
-           + QString("sectionNumberEnabled: %1,\n").arg(Utils::boolToString(m_sectionNumberEnabled))
-           + QString("transparentBackgroundEnabled: %1,\n").arg(Utils::boolToString(m_transparentBackgroundEnabled))
-           + QString("scrollable: %1,\n").arg(Utils::boolToString(m_scrollable))
-           + QString("bodyWidth: %1,\n").arg(m_bodyWidth)
-           + QString("bodyHeight: %1,\n").arg(m_bodyHeight)
-           + QString("transformSvgToPngEnabled: %1,\n").arg(Utils::boolToString(m_transformSvgToPngEnabled))
-           + QString("mathJaxScale: %1,\n").arg(m_mathJaxScale)
-           + QString("removeCodeToolBarEnabled: %1,\n").arg(Utils::boolToString(m_removeCodeToolBarEnabled))
-           + QString("sectionNumberBaseLevel: %1\n").arg(m_sectionNumberBaseLevel)
+           + QStringLiteral("webPlantUml: %1,\n").arg(Utils::boolToString(m_webPlantUml))
+           + QStringLiteral("plantUmlWebService: '%1',\n").arg(m_plantUmlWebService)
+           + QStringLiteral("webGraphviz: %1,\n").arg(Utils::boolToString(m_webGraphviz))
+           + QStringLiteral("mathJaxScript: '%1',\n").arg(m_mathJaxScript)
+           + QStringLiteral("constrainImageWidthEnabled: %1,\n").arg(Utils::boolToString(m_constrainImageWidthEnabled))
+           + QStringLiteral("imageAlignCenterEnabled: %1,\n").arg(Utils::boolToString(m_imageAlignCenterEnabled))
+           + QStringLiteral("protectFromXss: %1,\n").arg(Utils::boolToString(m_protectFromXss))
+           + QStringLiteral("htmlTagEnabled: %1,\n").arg(Utils::boolToString(m_htmlTagEnabled))
+           + QStringLiteral("autoBreakEnabled: %1,\n").arg(Utils::boolToString(m_autoBreakEnabled))
+           + QStringLiteral("linkifyEnabled: %1,\n").arg(Utils::boolToString(m_linkifyEnabled))
+           + QStringLiteral("indentFirstLineEnabled: %1,\n").arg(Utils::boolToString(m_indentFirstLineEnabled))
+           + QStringLiteral("codeBlockLineNumberEnabled: %1,\n").arg(Utils::boolToString(m_codeBlockLineNumberEnabled))
+           + QStringLiteral("sectionNumberEnabled: %1,\n").arg(Utils::boolToString(m_sectionNumberEnabled))
+           + QStringLiteral("transparentBackgroundEnabled: %1,\n").arg(Utils::boolToString(m_transparentBackgroundEnabled))
+           + QStringLiteral("scrollable: %1,\n").arg(Utils::boolToString(m_scrollable))
+           + QStringLiteral("bodyWidth: %1,\n").arg(m_bodyWidth)
+           + QStringLiteral("bodyHeight: %1,\n").arg(m_bodyHeight)
+           + QStringLiteral("transformSvgToPngEnabled: %1,\n").arg(Utils::boolToString(m_transformSvgToPngEnabled))
+           + QStringLiteral("mathJaxScale: %1,\n").arg(m_mathJaxScale)
+           + QStringLiteral("removeCodeToolBarEnabled: %1,\n").arg(Utils::boolToString(m_removeCodeToolBarEnabled))
+           + QStringLiteral("sectionNumberBaseLevel: %1\n").arg(m_sectionNumberBaseLevel)
            + QStringLiteral("}");
 }
 
@@ -83,7 +83,7 @@ static QString fillStyleTag(const QString &p_styleFile)
         return "";
     }
     auto url = PathUtils::pathToUrl(p_styleFile);
-    return QString("<link rel=\"stylesheet\" type=\"text/css\" href=\"%1\">\n").arg(url.toString());
+    return QStringLiteral("<link rel=\"stylesheet\" type=\"text/css\" href=\"%1\">\n").arg(url.toString());
 }
 
 static QString fillScriptTag(const QString &p_scriptFile)
@@ -92,7 +92,7 @@ static QString fillScriptTag(const QString &p_scriptFile)
         return "";
     }
     auto url = PathUtils::pathToUrl(p_scriptFile);
-    return QString("<script type=\"text/javascript\" src=\"%1\"></script>\n").arg(url.toString());
+    return QStringLiteral("<script type=\"text/javascript\" src=\"%1\"></script>\n").arg(url.toString());
 }
 
 static void fillThemeStyles(QString &p_template, const QString &p_webStyleSheetFile, const QString &p_highlightStyleSheetFile)
@@ -300,7 +300,7 @@ void HtmlTemplateHelper::fillTitle(QString &p_template, const QString &p_title)
 {
     if (!p_title.isEmpty()) {
         p_template.replace("<!-- VX_TITLE_PLACEHOLDER -->",
-                           QString("<title>%1</title>").arg(HtmlUtils::escapeHtml(p_title)));
+                           QStringLiteral("<title>%1</title>").arg(HtmlUtils::escapeHtml(p_title)));
     }
 }
 

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -86,7 +86,7 @@ void Logger::log(QtMsgType p_type, const QMessageLogContext &p_context, const QS
 
     if (!s_logToStderr) {
         QTextStream stream(&s_file);
-        stream << header << (QString("(%1:%2) ").arg(fileName).arg(p_context.line))
+        stream << header << (QStringLiteral("(%1:%2) ").arg(fileName).arg(p_context.line))
                << localMsg << "\n";
 
         if (p_type == QtFatalMsg) {

--- a/src/core/notebook/bundlenotebook.cpp
+++ b/src/core/notebook/bundlenotebook.cpp
@@ -93,7 +93,7 @@ void BundleNotebook::remove()
 
     // Remove notebook root folder if it is empty.
     if (!FileUtils::removeDirIfEmpty(getRootFolderAbsolutePath())) {
-        qInfo() << QString("root folder of notebook (%1) is not empty and needs manual clean up")
+        qInfo() << QStringLiteral("root folder of notebook (%1) is not empty and needs manual clean up")
                           .arg(getRootFolderAbsolutePath());
     }
 }

--- a/src/core/notebook/bundlenotebookfactory.cpp
+++ b/src/core/notebook/bundlenotebookfactory.cpp
@@ -40,7 +40,7 @@ static void checkRootFolderForNewNotebook(const NotebookParameters &p_paras)
         qCritical() << msg;
         throw Exception(Exception::Type::InvalidPath, msg);
     } else if (p_paras.m_ensureEmptyRootFolder && !PathUtils::isEmptyDir(p_paras.m_rootFolderPath)) {
-        QString msg = QString("local root folder must be empty: %1 (%2)")
+        QString msg = QStringLiteral("local root folder must be empty: %1 (%2)")
                              .arg(p_paras.m_rootFolderPath, PathUtils::absolutePath(p_paras.m_rootFolderPath));
         qCritical() << msg;
         throw Exception(Exception::Type::InvalidPath, msg);
@@ -88,7 +88,7 @@ void BundleNotebookFactory::checkParameters(const NotebookParameters &p_paras) c
     auto configMgr = dynamic_cast<BundleNotebookConfigMgr *>(p_paras.m_notebookConfigMgr.data());
     if (!configMgr) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("Invalid notebook configuration manager"));
+                            QStringLiteral("Invalid notebook configuration manager"));
     }
 }
 

--- a/src/core/notebook/notebook.cpp
+++ b/src/core/notebook/notebook.cpp
@@ -254,7 +254,7 @@ QSharedPointer<Node> Notebook::copyNodeAsChildOf(const QSharedPointer<Node> &p_s
 
     if (Node::isAncestor(p_src.data(), p_dest)) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("source (%1) is the ancestor of destination (%2)")
+                            QStringLiteral("source (%1) is the ancestor of destination (%2)")
                                    .arg(p_src->fetchPath(), p_dest->fetchPath()));
         return nullptr;
     }

--- a/src/core/notebook/notebookdatabaseaccess.cpp
+++ b/src/core/notebook/notebookdatabaseaccess.cpp
@@ -30,7 +30,7 @@ bool NotebookDatabaseAccess::open()
     auto db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), m_connectionName);
     db.setDatabaseName(m_databaseFile);
     if (!db.open()) {
-        qWarning() << QString("failed to open notebook database (%1) (%2)").arg(m_databaseFile, db.lastError().text());
+        qWarning() << QStringLiteral("failed to open notebook database (%1) (%2)").arg(m_databaseFile, db.lastError().text());
         return false;
     }
 
@@ -71,35 +71,35 @@ void NotebookDatabaseAccess::setupTables(QSqlDatabase &p_db, int p_configVersion
 
     if (m_fresh) {
         // Node.
-        bool ret = query.exec(QString("CREATE TABLE %1 (\n"
+        bool ret = query.exec(QStringLiteral("CREATE TABLE %1 (\n"
                                       "    id INTEGER PRIMARY KEY,\n"
                                       "    name TEXT NOT NULL,\n"
                                       "    signature INTEGER NOT NULL,\n"
                                       "    parent_id INTEGER NULL REFERENCES %1(id) ON DELETE CASCADE ON UPDATE CASCADE)\n").arg(c_nodeTableName));
         if (!ret) {
-            qWarning() << QString("failed to create database table (%1) (%2)").arg(c_nodeTableName, query.lastError().text());
+            qWarning() << QStringLiteral("failed to create database table (%1) (%2)").arg(c_nodeTableName, query.lastError().text());
             m_valid = false;
             return;
         }
 
         // Tag.
-        ret = query.exec(QString("CREATE TABLE %1 (\n"
+        ret = query.exec(QStringLiteral("CREATE TABLE %1 (\n"
                                  "    name TEXT PRIMARY KEY,\n"
                                  "    parent_name TEXT NULL REFERENCES %1(name) ON DELETE CASCADE ON UPDATE CASCADE) WITHOUT ROWID\n").arg(c_tagTableName));
         if (!ret) {
-            qWarning() << QString("failed to create database table (%1) (%2)").arg(c_tagTableName, query.lastError().text());
+            qWarning() << QStringLiteral("failed to create database table (%1) (%2)").arg(c_tagTableName, query.lastError().text());
             m_valid = false;
             return;
         }
 
         // Node_Tag.
-        ret = query.exec(QString("CREATE TABLE %1 (\n"
+        ret = query.exec(QStringLiteral("CREATE TABLE %1 (\n"
                                  "    node_id INTEGER REFERENCES %2(id) ON DELETE CASCADE ON UPDATE CASCADE,\n"
                                  "    tag_name TEXT REFERENCES %3(name) ON DELETE CASCADE ON UPDATE CASCADE)\n").arg(c_nodeTagTableName,
                                                                                                                      c_nodeTableName,
                                                                                                                      c_tagTableName));
         if (!ret) {
-            qWarning() << QString("failed to create database table (%1) (%2)").arg(c_nodeTagTableName, query.lastError().text());
+            qWarning() << QStringLiteral("failed to create database table (%1) (%2)").arg(c_nodeTagTableName, query.lastError().text());
             m_valid = false;
             return;
         }
@@ -130,7 +130,7 @@ bool NotebookDatabaseAccess::addNode(Node *p_node, bool p_ignoreId)
     auto db = getDatabase();
     QSqlQuery query(db);
     if (p_ignoreId) {
-        query.prepare(QString("INSERT INTO %1 (name, signature, parent_id)\n"
+        query.prepare(QStringLiteral("INSERT INTO %1 (name, signature, parent_id)\n"
                               "    VALUES (:name, :signature, :parent_id)").arg(c_nodeTableName));
         query.bindValue(":name", p_node->getName());
         query.bindValue(":signature", p_node->getSignature());
@@ -170,10 +170,10 @@ bool NotebookDatabaseAccess::addNode(Node *p_node, bool p_ignoreId)
         }
 
         if (useNewId) {
-            query.prepare(QString("INSERT INTO %1 (name, signature, parent_id)\n"
+            query.prepare(QStringLiteral("INSERT INTO %1 (name, signature, parent_id)\n"
                                   "    VALUES (:name, :signature, :parent_id)").arg(c_nodeTableName));
         } else {
-            query.prepare(QString("INSERT INTO %1 (id, name, signature, parent_id)\n"
+            query.prepare(QStringLiteral("INSERT INTO %1 (id, name, signature, parent_id)\n"
                                   "    VALUES (:id, :name, :signature, :parent_id)").arg(c_nodeTableName));
             query.bindValue(":id", p_node->getId());
         }
@@ -212,7 +212,7 @@ QSharedPointer<NotebookDatabaseAccess::NodeRecord> NotebookDatabaseAccess::query
 {
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("SELECT id, name, signature, parent_id FROM %1 WHERE id = :id").arg(c_nodeTableName));
+    query.prepare(QStringLiteral("SELECT id, name, signature, parent_id FROM %1 WHERE id = :id").arg(c_nodeTableName));
     query.bindValue(":id", p_id);
     if (!query.exec()) {
         qWarning() << "failed to query node" << query.executedQuery() << query.lastError().text();
@@ -264,7 +264,7 @@ QStringList NotebookDatabaseAccess::queryNodeParentPath(ID p_id)
 {
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("WITH RECURSIVE cte_parents(id, name, parent_id) AS (\n"
+    query.prepare(QStringLiteral("WITH RECURSIVE cte_parents(id, name, parent_id) AS (\n"
                           "    SELECT node.id, node.name, node.parent_id\n"
                           "    FROM %1 node\n"
                           "    WHERE node.id = :id\n"
@@ -315,7 +315,7 @@ bool NotebookDatabaseAccess::updateNode(const Node *p_node)
 
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("UPDATE %1\n"
+    query.prepare(QStringLiteral("UPDATE %1\n"
                           "SET name = :name,\n"
                           "    signature = :signature,\n"
                           "    parent_id = :parent_id\n"
@@ -367,7 +367,7 @@ bool NotebookDatabaseAccess::removeNode(ID p_id)
 {
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("DELETE FROM %1\n"
+    query.prepare(QStringLiteral("DELETE FROM %1\n"
                           "WHERE id = :id").arg(c_nodeTableName));
     query.bindValue(":id", p_id);
     if (!query.exec()) {
@@ -455,7 +455,7 @@ bool NotebookDatabaseAccess::addTag(const QString &p_name, const QString &p_pare
 
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("INSERT INTO %1 (name, parent_name)\n"
+    query.prepare(QStringLiteral("INSERT INTO %1 (name, parent_name)\n"
                           "    VALUES (:name, :parent_name)").arg(c_tagTableName));
     query.bindValue(":name", p_name);
     query.bindValue(":parent_name", p_parentName.isEmpty() ? QVariant() : p_parentName);
@@ -473,7 +473,7 @@ QSharedPointer<NotebookDatabaseAccess::TagRecord> NotebookDatabaseAccess::queryT
 {
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("SELECT name, parent_name FROM %1 WHERE name = :name").arg(c_tagTableName));
+    query.prepare(QStringLiteral("SELECT name, parent_name FROM %1 WHERE name = :name").arg(c_tagTableName));
     query.bindValue(":name", p_name);
     if (!query.exec()) {
         qWarning() << "failed to query tag" << query.executedQuery() << query.lastError().text();
@@ -494,7 +494,7 @@ bool NotebookDatabaseAccess::updateTagParent(const QString &p_name, const QStrin
 {
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("UPDATE %1\n"
+    query.prepare(QStringLiteral("UPDATE %1\n"
                           "SET parent_name = :parent_name\n"
                           "WHERE name = :name").arg(c_tagTableName));
     query.bindValue(":name", p_name);
@@ -518,7 +518,7 @@ bool NotebookDatabaseAccess::renameTag(const QString &p_name, const QString &p_n
 
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("UPDATE %1\n"
+    query.prepare(QStringLiteral("UPDATE %1\n"
                           "SET name = :new_name\n"
                           "WHERE name = :name").arg(c_tagTableName));
     query.bindValue(":name", p_name);
@@ -537,7 +537,7 @@ bool NotebookDatabaseAccess::removeTag(const QString &p_name)
 {
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("DELETE FROM %1\n"
+    query.prepare(QStringLiteral("DELETE FROM %1\n"
                           "WHERE name = :name").arg(c_tagTableName));
     query.bindValue(":name", p_name);
     if (!query.exec()) {
@@ -603,7 +603,7 @@ QStringList NotebookDatabaseAccess::queryNodeTags(ID p_id)
 {
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("SELECT tag_name FROM %1 WHERE node_id = :node_id").arg(c_nodeTagTableName));
+    query.prepare(QStringLiteral("SELECT tag_name FROM %1 WHERE node_id = :node_id").arg(c_nodeTagTableName));
     query.bindValue(":node_id", p_id);
     if (!query.exec()) {
         qWarning() << "failed to query node's tags" << query.executedQuery() << query.lastError().text();
@@ -621,7 +621,7 @@ bool NotebookDatabaseAccess::removeNodeTags(ID p_id)
 {
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("DELETE FROM %1\n"
+    query.prepare(QStringLiteral("DELETE FROM %1\n"
                           "WHERE node_id = :node_id").arg(c_nodeTagTableName));
     query.bindValue(":node_id", p_id);
     if (!query.exec()) {
@@ -641,7 +641,7 @@ bool NotebookDatabaseAccess::addNodeTags(ID p_id, const QStringList &p_tags)
 
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("INSERT INTO %1 (node_id, tag_name)\n"
+    query.prepare(QStringLiteral("INSERT INTO %1 (node_id, tag_name)\n"
                           "    VALUES (?, ?)").arg(c_nodeTagTableName));
 
     QVariantList ids;
@@ -668,7 +668,7 @@ QList<ID> NotebookDatabaseAccess::queryTagNodes(const QString &p_tag)
     QList<ID> nodes;
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("SELECT node_id FROM %1 WHERE tag_name = :tag_name").arg(c_nodeTagTableName));
+    query.prepare(QStringLiteral("SELECT node_id FROM %1 WHERE tag_name = :tag_name").arg(c_nodeTagTableName));
     query.bindValue(":tag_name", p_tag);
     if (!query.exec()) {
         qWarning() << "failed to query nodes of tag" << query.executedQuery() << query.lastError().text();
@@ -703,7 +703,7 @@ QStringList NotebookDatabaseAccess::queryTagAndChildren(const QString &p_tag)
 {
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("WITH RECURSIVE cte_children(name, parent_name) AS (\n"
+    query.prepare(QStringLiteral("WITH RECURSIVE cte_children(name, parent_name) AS (\n"
                           "    SELECT tag.name, tag.parent_name\n"
                           "    FROM %1 tag\n"
                           "    WHERE tag.name = :name\n"
@@ -768,7 +768,7 @@ QList<NotebookDatabaseAccess::TagRecord> NotebookDatabaseAccess::getAllTags()
 
     auto db = getDatabase();
     QSqlQuery query(db);
-    query.prepare(QString("SELECT name, parent_name FROM %1 ORDER BY parent_name, name").arg(c_tagTableName));
+    query.prepare(QStringLiteral("SELECT name, parent_name FROM %1 ORDER BY parent_name, name").arg(c_tagTableName));
     if (!query.exec()) {
         qWarning() << "failed to query tags" << query.executedQuery() << query.lastError().text();
         return ret;

--- a/src/core/notebookbackend/inotebookbackend.cpp
+++ b/src/core/notebookbackend/inotebookbackend.cpp
@@ -11,7 +11,7 @@ void INotebookBackend::constrainPath(const QString &p_path) const
 {
     if (!PathUtils::pathContains(m_rootPath, p_path)) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("path (%1) does not locate in root folder (%2)")
+                            QStringLiteral("path (%1) does not locate in root folder (%2)")
                                    .arg(p_path, m_rootPath));
     }
 }

--- a/src/core/notebookbackend/localnotebookbackend.cpp
+++ b/src/core/notebookbackend/localnotebookbackend.cpp
@@ -52,7 +52,7 @@ void LocalNotebookBackend::makePath(const QString &p_dirPath)
     QDir dir(getRootPath());
     if (!dir.mkpath(p_dirPath)) {
         Exception::throwOne(Exception::Type::FailToCreateDir,
-                            QString("fail to create directory: %1").arg(p_dirPath));
+                            QStringLiteral("fail to create directory: %1").arg(p_dirPath));
     }
 }
 

--- a/src/core/notebookconfigmgr/notebookconfig.cpp
+++ b/src/core/notebookconfigmgr/notebookconfig.cpp
@@ -56,7 +56,7 @@ void NotebookConfig::fromJson(const QJsonObject &p_jobj)
         || !p_jobj.contains(QStringLiteral("version_controller"))
         || !p_jobj.contains(QStringLiteral("config_mgr"))) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("failed to read notebook configuration from JSON (%1)").arg(QJsonObjectToString(p_jobj)));
+                            QStringLiteral("failed to read notebook configuration from JSON (%1)").arg(QJsonObjectToString(p_jobj)));
         return;
     }
 

--- a/src/core/notebookconfigmgr/vxnotebookconfigmgr.cpp
+++ b/src/core/notebookconfigmgr/vxnotebookconfigmgr.cpp
@@ -126,12 +126,12 @@ QSharedPointer<NodeConfig> VXNotebookConfigMgr::readNodeConfig(const QString &p_
     auto backend = getBackend();
     if (!backend->exists(p_path)) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("node path (%1) does not exist").arg(p_path));
+                            QStringLiteral("node path (%1) does not exist").arg(p_path));
     }
 
     if (backend->isFile(p_path)) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("node (%1) is a file node without config").arg(p_path));
+                            QStringLiteral("node (%1) is a file node without config").arg(p_path));
     } else {
         auto configPath = PathUtils::concatenateFilePath(p_path, c_nodeConfigName);
         auto data = backend->readFile(configPath);
@@ -309,7 +309,7 @@ QSharedPointer<Node> VXNotebookConfigMgr::newFileNode(Node *p_parent,
         if (getBackend()->childExistsCaseInsensitive(p_parent->fetchPath(), p_name)) {
             // File already exists. Exception.
             Exception::throwOne(Exception::Type::FileExistsOnCreate,
-                                QString("file (%1) already exists when creating new node").arg(node->fetchPath()));
+                                QStringLiteral("file (%1) already exists when creating new node").arg(node->fetchPath()));
             return nullptr;
         }
 
@@ -345,7 +345,7 @@ QSharedPointer<Node> VXNotebookConfigMgr::newFolderNode(Node *p_parent,
         if (getBackend()->childExistsCaseInsensitive(p_parent->fetchPath(), p_name)) {
             // Dir already exists. Exception.
             Exception::throwOne(Exception::Type::DirExistsOnCreate,
-                                QString("dir (%1) already exists when creating new node").arg(node->fetchPath()));
+                                QStringLiteral("dir (%1) already exists when creating new node").arg(node->fetchPath()));
             return nullptr;
         }
 

--- a/src/core/notebookmgr.cpp
+++ b/src/core/notebookmgr.cpp
@@ -108,7 +108,7 @@ QSharedPointer<INotebookBackend> NotebookMgr::createNotebookBackend(const QStrin
         return factory->createNotebookBackend(p_rootFolderPath);
     } else {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("failed to find notebook backend factory %1").arg(p_backendName));
+                            QStringLiteral("failed to find notebook backend factory %1").arg(p_backendName));
     }
 
     return nullptr;
@@ -121,7 +121,7 @@ QSharedPointer<IVersionController> NotebookMgr::createVersionController(const QS
         return factory->createVersionController();
     } else {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("failed to find version controller factory %1").arg(p_controllerName));
+                            QStringLiteral("failed to find version controller factory %1").arg(p_controllerName));
     }
 
     return nullptr;
@@ -135,7 +135,7 @@ QSharedPointer<INotebookConfigMgr> NotebookMgr::createNotebookConfigMgr(const QS
         return factory->createNotebookConfigMgr(p_backend);
     } else {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("failed to find notebook config manager factory %1").arg(p_mgrName));
+                            QStringLiteral("failed to find notebook config manager factory %1").arg(p_mgrName));
     }
 
     return nullptr;
@@ -171,7 +171,7 @@ QSharedPointer<Notebook> NotebookMgr::newNotebook(const QSharedPointer<NotebookP
     auto factory = m_notebookServer->getItem(p_parameters->m_type);
     if (!factory) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("failed to find notebook factory %1").arg(p_parameters->m_type));
+                            QStringLiteral("failed to find notebook factory %1").arg(p_parameters->m_type));
     }
 
     auto notebook = factory->newNotebook(*p_parameters);
@@ -246,7 +246,7 @@ QSharedPointer<Notebook> NotebookMgr::readNotebookFromConfig(const SessionConfig
     auto factory = m_notebookServer->getItem(p_item.m_type);
     if (!factory) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("failed to find notebook factory %1").arg(p_item.m_type));
+                            QStringLiteral("failed to find notebook factory %1").arg(p_item.m_type));
     }
 
     auto backend = createNotebookBackend(p_item.m_backend, p_item.m_rootFolderPath);
@@ -330,7 +330,7 @@ void NotebookMgr::closeNotebook(ID p_id)
     emit notebooksUpdated();
     setCurrentNotebookAfterUpdate();
 
-    qInfo() << QString("notebook %1 (%2) is closed").arg(notebookToClose->getName(),
+    qInfo() << QStringLiteral("notebook %1 (%2) is closed").arg(notebookToClose->getName(),
                                                          notebookToClose->getRootFolderPath());
 }
 
@@ -359,13 +359,13 @@ void NotebookMgr::removeNotebook(ID p_id)
     try {
         nbToRemove->remove();
     } catch (Exception &p_e) {
-        qWarning() << QString("failed to remove notebook %1 (%2) (%3)").arg(nbToRemove->getName(),
+        qWarning() << QStringLiteral("failed to remove notebook %1 (%2) (%3)").arg(nbToRemove->getName(),
                                                                           nbToRemove->getRootFolderPath(),
                                                                           p_e.what());
         throw;
     }
 
-    qInfo() << QString("notebook %1 (%2) is removed").arg(nbToRemove->getName(),
+    qInfo() << QStringLiteral("notebook %1 (%2) is removed").arg(nbToRemove->getName(),
                                                           nbToRemove->getRootFolderPath());
 }
 

--- a/src/core/sessionconfig.cpp
+++ b/src/core/sessionconfig.cpp
@@ -87,7 +87,7 @@ QJsonObject SessionConfig::ExternalProgram::toJson() const
 QString SessionConfig::ExternalProgram::fetchCommand(const QString &p_file) const
 {
     auto command(m_command);
-    command.replace(QStringLiteral("%1"), QString("\"%1\"").arg(p_file));
+    command.replace(QStringLiteral("%1"), QStringLiteral("\"%1\"").arg(p_file));
     return command;
 }
 

--- a/src/core/theme.cpp
+++ b/src/core/theme.cpp
@@ -50,12 +50,12 @@ QString Theme::getDisplayName(const QString &p_folder, const QString &p_locale)
 
     if (!p_locale.isEmpty()) {
         // Check full locale.
-        auto fullLocale = QString("%1_%2").arg(prefix, p_locale);
+        auto fullLocale = QStringLiteral("%1_%2").arg(prefix, p_locale);
         if (metaObj.contains(fullLocale)) {
             return metaObj.value(fullLocale).toString();
         }
 
-        auto shortLocale = QString("%1_%2").arg(prefix, p_locale.split('_')[0]);
+        auto shortLocale = QStringLiteral("%1_%2").arg(prefix, p_locale.split('_')[0]);
         if (metaObj.contains(shortLocale)) {
             return metaObj.value(shortLocale).toString();
         }
@@ -297,7 +297,7 @@ void Theme::translateUrlToAbsolute(const QString &p_basePath, QString &p_style)
     const int urlCapturedIdx = 2;
 
     QDir dir(p_basePath);
-    const int literalSize = QString("url(").size();
+    const int literalSize = QStringLiteral("url(").size();
     int pos = 0;
     QRegularExpressionMatch match;
     while (pos < p_style.size()) {
@@ -346,7 +346,7 @@ void Theme::translateFontFamilyList(QString &p_style)
                 family = "\"" + family + "\"";
             }
 
-            auto newStr = QString("%1font-family: %2;").arg(match.captured(prefixCapturedIdx), family);
+            auto newStr = QStringLiteral("%1font-family: %2;").arg(match.captured(prefixCapturedIdx), family);
             p_style.replace(idx, match.capturedLength(), newStr);
             pos = idx + newStr.size();
         } else {
@@ -381,7 +381,7 @@ void Theme::translateScaledSize(qreal p_factor, QString &p_style)
         }
 
         val = val * p_factor + 0.5;
-        auto newStr = QString("%1%2%3").arg(match.captured(prefixCapturedIdx),
+        auto newStr = QStringLiteral("%1%2%3").arg(match.captured(prefixCapturedIdx),
                                             match.captured(signCapturedIdx),
                                             QString::number(val));
         p_style.replace(idx, match.capturedLength(), newStr);

--- a/src/core/thememgr.cpp
+++ b/src/core/thememgr.cpp
@@ -56,7 +56,7 @@ void ThemeMgr::loadAvailableThemes()
 
     if (m_themes.isEmpty()) {
         Exception::throwOne(Exception::Type::EssentialFileMissing,
-                            QString("no available themes found in paths: %1").arg(s_searchPaths.join(QLatin1Char(';'))));
+                            QStringLiteral("no available themes found in paths: %1").arg(s_searchPaths.join(QLatin1Char(';'))));
     }
 }
 

--- a/src/export/exporter.cpp
+++ b/src/export/exporter.cpp
@@ -677,7 +677,7 @@ QString Exporter::evaluateCommand(const ExportOption &p_option,
 
 QString Exporter::getQuotedPath(const QString &p_path)
 {
-    return QString("\"%1\"").arg(QDir::toNativeSeparators(p_path));
+    return QStringLiteral("\"%1\"").arg(QDir::toNativeSeparators(p_path));
 }
 
 void Exporter::collectFiles(const QList<QSharedPointer<File>> &p_files, QStringList &p_inputFiles, QStringList &p_resourcePaths)

--- a/src/export/webviewexporter.cpp
+++ b/src/export/webviewexporter.cpp
@@ -201,7 +201,7 @@ bool WebViewExporter::writeHtmlFile(const QString &p_file,
 
     auto htmlContent = m_exportHtmlTemplate;
 
-    const auto title = QString("%1").arg(baseName);
+    const auto title = QStringLiteral("%1").arg(baseName);
     HtmlTemplateHelper::fillTitle(htmlContent, title);
 
     if (!p_styleContent.isEmpty() && p_embedStyles) {
@@ -311,7 +311,7 @@ void WebViewExporter::prepare(const ExportOption &p_option)
 
 static QString marginToStrMM(qreal p_margin)
 {
-    return QString("%1mm").arg(p_margin);
+    return QStringLiteral("%1mm").arg(p_margin);
 }
 
 void WebViewExporter::prepareWkhtmltopdfArguments(const ExportPdfOption &p_pdfOption)
@@ -374,7 +374,7 @@ bool WebViewExporter::embedStyleResources(QString &p_html) const
             pos = idx + match.capturedLength();
         } else {
             // Replace the url string in html.
-            QString newUrl = QString("url('%1');").arg(dataURI);
+            QString newUrl = QStringLiteral("url('%1');").arg(dataURI);
             p_html.replace(idx, match.capturedLength(), newUrl);
             pos = idx + newUrl.size();
             altered = true;
@@ -412,7 +412,7 @@ bool WebViewExporter::embedBodyResources(const QUrl &p_baseUrl, QString &p_html)
             pos = idx + match.capturedLength();
         } else {
             // Replace the url string in html.
-            QString newUrl = QString("<img %1src='%2'%3>").arg(match.captured(1), dataURI, match.captured(3));
+            QString newUrl = QStringLiteral("<img %1src='%2'%3>").arg(match.captured(1), dataURI, match.captured(3));
             p_html.replace(idx, match.capturedLength(), newUrl);
             pos = idx + newUrl.size();
             altered = true;
@@ -460,7 +460,7 @@ bool WebViewExporter::fixBodyResources(const QUrl &p_baseUrl,
             pos = idx + match.capturedLength();
         } else {
             // Replace the url string in html.
-            QString newUrl = QString("<img %1src=\"%2\"%3>").arg(match.captured(1), getResourceRelativePath(targetFile), match.captured(3));
+            QString newUrl = QStringLiteral("<img %1src=\"%2\"%3>").arg(match.captured(1), getResourceRelativePath(targetFile), match.captured(3));
             p_html.replace(idx, match.capturedLength(), newUrl);
             pos = idx + newUrl.size();
             altered = true;

--- a/src/imagehost/giteeimagehost.cpp
+++ b/src/imagehost/giteeimagehost.cpp
@@ -40,7 +40,7 @@ void GiteeImageHost::setConfig(const QJsonObject &p_jobj)
     parseConfig(p_jobj, m_personalAccessToken, m_userName, m_repoName);
 
     // Do not assume the default branch.
-    m_imageUrlPrefix = QString("https://gitee.com/%1/%2/raw/").arg(m_userName, m_repoName);
+    m_imageUrlPrefix = QStringLiteral("https://gitee.com/%1/%2/raw/").arg(m_userName, m_repoName);
 }
 
 vte::NetworkAccess::RawHeaderPairs GiteeImageHost::prepareCommonHeaders()
@@ -53,9 +53,9 @@ vte::NetworkAccess::RawHeaderPairs GiteeImageHost::prepareCommonHeaders()
 QString GiteeImageHost::addAccessToken(const QString &p_token, QString p_url)
 {
     if (p_url.contains(QLatin1Char('?'))) {
-        p_url += QString("&access_token=%1").arg(p_token);
+        p_url += QStringLiteral("&access_token=%1").arg(p_token);
     } else {
-        p_url += QString("?access_token=%1").arg(p_token);
+        p_url += QStringLiteral("?access_token=%1").arg(p_token);
     }
     return p_url;
 }
@@ -63,7 +63,7 @@ QString GiteeImageHost::addAccessToken(const QString &p_token, QString p_url)
 vte::NetworkReply GiteeImageHost::getRepoInfo(const QString &p_token, const QString &p_userName, const QString &p_repoName) const
 {
     auto rawHeader = prepareCommonHeaders();
-    auto urlStr = QString("%1/repos/%2/%3").arg(c_apiUrl, p_userName, p_repoName);
+    auto urlStr = QStringLiteral("%1/repos/%2/%3").arg(c_apiUrl, p_userName, p_repoName);
     auto reply = vte::NetworkAccess::request(QUrl(addAccessToken(p_token, urlStr)), rawHeader);
     return reply;
 }
@@ -88,7 +88,7 @@ QString GiteeImageHost::create(const QByteArray &p_data, const QString &p_path, 
     }
 
     auto rawHeader = prepareCommonHeaders();
-    const auto urlStr = QString("%1/repos/%2/%3/contents/%4").arg(c_apiUrl, m_userName, m_repoName, p_path);
+    const auto urlStr = QStringLiteral("%1/repos/%2/%3/contents/%4").arg(c_apiUrl, m_userName, m_repoName, p_path);
 
     // Check if @p_path already exists.
     auto reply = vte::NetworkAccess::request(QUrl(addAccessToken(m_personalAccessToken, urlStr)), rawHeader);
@@ -105,7 +105,7 @@ QString GiteeImageHost::create(const QByteArray &p_data, const QString &p_path, 
     // Create the content.
     QJsonObject requestDataObj;
     requestDataObj[QStringLiteral("access_token")] = m_personalAccessToken;
-    requestDataObj[QStringLiteral("message")] = QString("VX_ADD: %1").arg(p_path);
+    requestDataObj[QStringLiteral("message")] = QStringLiteral("VX_ADD: %1").arg(p_path);
     requestDataObj[QStringLiteral("content")] = QString::fromUtf8(p_data.toBase64());
     auto requestData = Utils::toJsonString(requestDataObj);
     reply = vte::NetworkAccess::post(QUrl(urlStr), rawHeader, requestData);
@@ -143,7 +143,7 @@ bool GiteeImageHost::remove(const QString &p_url, QString &p_msg)
     const auto resourcePath = fetchResourcePath(m_imageUrlPrefix, p_url);
 
     auto rawHeader = prepareCommonHeaders();
-    const auto urlStr = QString("%1/repos/%2/%3/contents/%4").arg(c_apiUrl, m_userName, m_repoName, resourcePath);
+    const auto urlStr = QStringLiteral("%1/repos/%2/%3/contents/%4").arg(c_apiUrl, m_userName, m_repoName, resourcePath);
 
     // Get the SHA of the resource.
     auto reply = vte::NetworkAccess::request(QUrl(addAccessToken(m_personalAccessToken, urlStr)), rawHeader);
@@ -163,7 +163,7 @@ bool GiteeImageHost::remove(const QString &p_url, QString &p_msg)
     // Delete.
     QJsonObject requestDataObj;
     requestDataObj[QStringLiteral("access_token")] = m_personalAccessToken;
-    requestDataObj[QStringLiteral("message")] = QString("VX_DEL: %1").arg(resourcePath);
+    requestDataObj[QStringLiteral("message")] = QStringLiteral("VX_DEL: %1").arg(resourcePath);
     requestDataObj[QStringLiteral("sha")] = sha;
     auto requestData = Utils::toJsonString(requestDataObj);
     reply = vte::NetworkAccess::deleteResource(QUrl(urlStr), rawHeader, requestData);

--- a/src/imagehost/githubimagehost.cpp
+++ b/src/imagehost/githubimagehost.cpp
@@ -41,7 +41,7 @@ void GitHubImageHost::setConfig(const QJsonObject &p_jobj)
     parseConfig(p_jobj, m_personalAccessToken, m_userName, m_repoName);
 
     // Do not assume the default branch.
-    m_imageUrlPrefix = QString("https://raw.githubusercontent.com/%1/%2/").arg(m_userName, m_repoName);
+    m_imageUrlPrefix = QStringLiteral("https://raw.githubusercontent.com/%1/%2/").arg(m_userName, m_repoName);
 }
 
 QPair<QByteArray, QByteArray> GitHubImageHost::authorizationHeader(const QString &p_token)
@@ -66,7 +66,7 @@ vte::NetworkAccess::RawHeaderPairs GitHubImageHost::prepareCommonHeaders(const Q
 vte::NetworkReply GitHubImageHost::getRepoInfo(const QString &p_token, const QString &p_userName, const QString &p_repoName) const
 {
     auto rawHeader = prepareCommonHeaders(p_token);
-    const auto urlStr = QString("%1/repos/%2/%3").arg(c_apiUrl, p_userName, p_repoName);
+    const auto urlStr = QStringLiteral("%1/repos/%2/%3").arg(c_apiUrl, p_userName, p_repoName);
     auto reply = vte::NetworkAccess::request(QUrl(urlStr), rawHeader);
     return reply;
 }
@@ -86,7 +86,7 @@ QString GitHubImageHost::create(const QByteArray &p_data, const QString &p_path,
     }
 
     auto rawHeader = prepareCommonHeaders(m_personalAccessToken);
-    const auto urlStr = QString("%1/repos/%2/%3/contents/%4").arg(c_apiUrl, m_userName, m_repoName, p_path);
+    const auto urlStr = QStringLiteral("%1/repos/%2/%3/contents/%4").arg(c_apiUrl, m_userName, m_repoName, p_path);
 
     // Check if @p_path already exists.
     auto reply = vte::NetworkAccess::request(QUrl(urlStr), rawHeader);
@@ -100,7 +100,7 @@ QString GitHubImageHost::create(const QByteArray &p_data, const QString &p_path,
 
     // Create the content.
     QJsonObject requestDataObj;
-    requestDataObj[QStringLiteral("message")] = QString("VX_ADD: %1").arg(p_path);
+    requestDataObj[QStringLiteral("message")] = QStringLiteral("VX_ADD: %1").arg(p_path);
     requestDataObj[QStringLiteral("content")] = QString::fromUtf8(p_data.toBase64());
     auto requestData = Utils::toJsonString(requestDataObj);
     reply = vte::NetworkAccess::put(QUrl(urlStr), rawHeader, requestData);
@@ -137,7 +137,7 @@ bool GitHubImageHost::remove(const QString &p_url, QString &p_msg)
     const auto resourcePath = fetchResourcePath(m_imageUrlPrefix, p_url);
 
     auto rawHeader = prepareCommonHeaders(m_personalAccessToken);
-    const auto urlStr = QString("%1/repos/%2/%3/contents/%4").arg(c_apiUrl, m_userName, m_repoName, resourcePath);
+    const auto urlStr = QStringLiteral("%1/repos/%2/%3/contents/%4").arg(c_apiUrl, m_userName, m_repoName, resourcePath);
 
     // Get the SHA of the resource.
     QString sha = "";
@@ -177,7 +177,7 @@ bool GitHubImageHost::remove(const QString &p_url, QString &p_msg)
 
     // Delete.
     QJsonObject requestDataObj;
-    requestDataObj[QStringLiteral("message")] = QString("VX_DEL: %1").arg(resourcePath);
+    requestDataObj[QStringLiteral("message")] = QStringLiteral("VX_DEL: %1").arg(resourcePath);
     requestDataObj[QStringLiteral("sha")] = sha;
     auto requestData = Utils::toJsonString(requestDataObj);
     reply = vte::NetworkAccess::deleteResource(QUrl(urlStr), rawHeader, requestData);

--- a/src/imagehost/imagehost.cpp
+++ b/src/imagehost/imagehost.cpp
@@ -28,6 +28,6 @@ QString ImageHost::typeString(ImageHost::Type p_type)
 
     default:
         Q_ASSERT(false);
-        return QString("Unknown");
+        return QStringLiteral("Unknown");
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
 
     case CommandLineOptions::VersionRequested:
     {
-        auto versionStr = QString("%1 %2").arg(app.applicationName()).arg(app.applicationVersion());
+        auto versionStr = QStringLiteral("%1 %2").arg(app.applicationName()).arg(app.applicationVersion());
         showMessageOnCommandLineIfAvailable(versionStr);
         return 0;
     }
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
     // Init logger after app info is set.
     Logger::init(cmdOptions.m_verbose, cmdOptions.m_logToStderr);
 
-    qInfo() << QString("%1 (v%2) started at %3 (%4)").arg(ConfigMgr::c_appName,
+    qInfo() << QStringLiteral("%1 (v%2) started at %3 (%4)").arg(ConfigMgr::c_appName,
                                                           app.applicationVersion(),
                                                           QDateTime::currentDateTime().toString(),
                                                           QSysInfo::productType());
@@ -258,7 +258,7 @@ void showMessageOnCommandLineIfAvailable(const QString &p_msg)
 {
 #if defined(Q_OS_WIN)
     MessageBoxHelper::notify(MessageBoxHelper::Information,
-                             QString("<pre>%1</pre>").arg(p_msg));
+                             QStringLiteral("<pre>%1</pre>").arg(p_msg));
 #else
     fprintf(stderr, "%s\n", qPrintable(p_msg));
 #endif

--- a/src/snippet/snippetmgr.cpp
+++ b/src/snippet/snippetmgr.cpp
@@ -22,7 +22,7 @@ using namespace vnotex;
 
 const QChar SnippetMgr::c_snippetSymbolGuard = QLatin1Char('%');
 
-const QString SnippetMgr::c_snippetSymbolRegExp = QString("%1([^%]+)%1").arg(c_snippetSymbolGuard);
+const QString SnippetMgr::c_snippetSymbolRegExp = QStringLiteral("%1([^%]+)%1").arg(c_snippetSymbolGuard);
 
 SnippetMgr::SnippetMgr()
 {

--- a/src/task/taskvariablemgr.cpp
+++ b/src/task/taskvariablemgr.cpp
@@ -279,13 +279,13 @@ void TaskVariableMgr::initInputVariables()
     addVariable("input", [this](Task *task, const QString &val) {
         if (val.isEmpty()) {
             Exception::throwOne(Exception::Type::InvalidArgument,
-                                QString("task (%1) with empty input id").arg(task->getLabel()));
+                                QStringLiteral("task (%1) with empty input id").arg(task->getLabel()));
         }
 
         auto input = task->findInput(val);
         if (!input) {
             Exception::throwOne(Exception::Type::InvalidArgument,
-                                QString("task (%1) with invalid input id (%2)").arg(task->getLabel(), val));
+                                QStringLiteral("task (%1) with invalid input id (%2)").arg(task->getLabel(), val));
         }
 
         if (input->type == "promptString") {
@@ -319,7 +319,7 @@ void TaskVariableMgr::initInputVariables()
             }
         } else {
             Exception::throwOne(Exception::Type::InvalidArgument,
-                                QString("task (%1) with invalid input type (%2)(%3)").arg(task->getLabel(), input->id, input->type));
+                                QStringLiteral("task (%1) with invalid input type (%2)(%3)").arg(task->getLabel(), input->id, input->type));
         }
 
         return QString();
@@ -337,7 +337,7 @@ void TaskVariableMgr::initShellVariables()
         const int timeout = 1000;
         if (!process.waitForStarted(timeout) || !process.waitForFinished(timeout)) {
             Exception::throwOne(Exception::Type::InvalidArgument,
-                                QString("task (%1) failed to fetch shell variable (%2)").arg(task->getLabel(), val));
+                                QStringLiteral("task (%1) failed to fetch shell variable (%2)").arg(task->getLabel(), val));
         }
         return Task::decodeText(process.readAllStandardOutput());
     });

--- a/src/utils/contentmediautils.cpp
+++ b/src/utils/contentmediautils.cpp
@@ -107,7 +107,7 @@ void ContentMediaUtils::copyMarkdownMediaFiles(const QString &p_content,
             // Rename happens.
             const auto oldFileName = PathUtils::fileName(oldDestFilePath);
             const auto newFileName = PathUtils::fileName(destFilePath);
-            qWarning() << QString("image name conflicts when copy, renamed from (%1) to (%2)").arg(oldFileName, newFileName);
+            qWarning() << QStringLiteral("image name conflicts when copy, renamed from (%1) to (%2)").arg(oldFileName, newFileName);
 
             // Update the text content.
             const auto encodedOldFileName = PathUtils::fileName(link.m_urlInLink);

--- a/src/utils/docsutils.cpp
+++ b/src/utils/docsutils.cpp
@@ -29,9 +29,9 @@ QString DocsUtils::getDocFile(const QString &p_baseName)
 {
     const auto shortLocale = s_locale.split('_')[0];
 
-    const auto fullLocaleName = QString("%1/%2").arg(s_locale, p_baseName);
-    const auto shortLocaleName = QString("%1/%2").arg(shortLocale, p_baseName);
-    const auto defaultLocaleName = QString("%1/%2").arg(QStringLiteral("en"), p_baseName);
+    const auto fullLocaleName = QStringLiteral("%1/%2").arg(s_locale, p_baseName);
+    const auto shortLocaleName = QStringLiteral("%1/%2").arg(shortLocale, p_baseName);
+    const auto defaultLocaleName = QStringLiteral("%1/%2").arg(QStringLiteral("en"), p_baseName);
 
     for (const auto &pa : s_searchPaths) {
         QDir dir(pa);

--- a/src/utils/fileutils.cpp
+++ b/src/utils/fileutils.cpp
@@ -19,7 +19,7 @@ QByteArray FileUtils::readFile(const QString &p_filePath)
     QFile file(p_filePath);
     if (!file.open(QIODevice::ReadOnly)) {
         Exception::throwOne(Exception::Type::FailToReadFile,
-                            QString("failed to read file: %1").arg(p_filePath));
+                            QStringLiteral("failed to read file: %1").arg(p_filePath));
     }
 
     return file.readAll();
@@ -30,7 +30,7 @@ QString FileUtils::readTextFile(const QString &p_filePath)
     QFile file(p_filePath);
     if (!file.open(QIODevice::ReadOnly)) {
         Exception::throwOne(Exception::Type::FailToReadFile,
-                            QString("failed to read file: %1").arg(p_filePath));
+                            QStringLiteral("failed to read file: %1").arg(p_filePath));
     }
 
     // TODO: determine the encoding of the text.
@@ -49,7 +49,7 @@ void FileUtils::writeFile(const QString &p_filePath, const QByteArray &p_data)
     QFile file(p_filePath);
     if (!file.open(QIODevice::WriteOnly)) {
         Exception::throwOne(Exception::Type::FailToWriteFile,
-                            QString("failed to write to file: %1").arg(p_filePath));
+                            QStringLiteral("failed to write to file: %1").arg(p_filePath));
     }
 
     file.write(p_data);
@@ -61,7 +61,7 @@ void FileUtils::writeFile(const QString &p_filePath, const QString &p_text)
     QFile file(p_filePath);
     if (!file.open(QIODevice::WriteOnly)) {
         Exception::throwOne(Exception::Type::FailToWriteFile,
-                            QString("failed to write to file: %1").arg(p_filePath));
+                            QStringLiteral("failed to write to file: %1").arg(p_filePath));
     }
 
     QTextStream stream(&file);
@@ -81,7 +81,7 @@ void FileUtils::renameFile(const QString &p_path, const QString &p_name)
     QFile file(p_path);
     if (!file.exists() || !file.rename(newFilePath)) {
         Exception::throwOne(Exception::Type::FailToRenameFile,
-                            QString("failed to rename file: %1").arg(p_path));
+                            QStringLiteral("failed to rename file: %1").arg(p_path));
     }
 }
 
@@ -119,7 +119,7 @@ void FileUtils::copyFile(const QString &p_filePath,
     QDir dir;
     if (!dir.mkpath(PathUtils::parentDirPath(p_destPath))) {
         Exception::throwOne(Exception::Type::FailToCreateDir,
-                            QString("failed to create directory: %1").arg(PathUtils::parentDirPath(p_destPath)));
+                            QStringLiteral("failed to create directory: %1").arg(PathUtils::parentDirPath(p_destPath)));
     }
 
     bool failed = false;
@@ -136,7 +136,7 @@ void FileUtils::copyFile(const QString &p_filePath,
 
     if (failed) {
         Exception::throwOne(Exception::Type::FailToCopyFile,
-                            QString("failed to copy file: %1 %2").arg(p_filePath, p_destPath));
+                            QStringLiteral("failed to copy file: %1 %2").arg(p_filePath, p_destPath));
     }
 }
 
@@ -150,7 +150,7 @@ void FileUtils::copyDir(const QString &p_dirPath,
 
     if (QFileInfo::exists(p_destPath)) {
         Exception::throwOne(Exception::Type::FailToCopyDir,
-                            QString("target directory %1 already exists").arg(p_destPath));
+                            QStringLiteral("target directory %1 already exists").arg(p_destPath));
     }
 
     // QDir.rename() could not move directory across dirves.
@@ -159,7 +159,7 @@ void FileUtils::copyDir(const QString &p_dirPath,
     QDir destDir(p_destPath);
     if (!destDir.mkpath(p_destPath)) {
         Exception::throwOne(Exception::Type::FailToCreateDir,
-            QString("failed to create directory: %1").arg(p_destPath));
+            QStringLiteral("failed to create directory: %1").arg(p_destPath));
     }
 
     // Copy directory contents recursively.
@@ -182,7 +182,7 @@ void FileUtils::copyDir(const QString &p_dirPath,
     if (p_move) {
         if (!destDir.rmdir(p_dirPath)) {
             Exception::throwOne(Exception::Type::FailToRemoveDir,
-                QString("failed to remove source directory after move: %1").arg(p_dirPath));
+                QStringLiteral("failed to remove source directory after move: %1").arg(p_dirPath));
         }
     }
 }
@@ -196,7 +196,7 @@ QString FileUtils::renameIfExistsCaseInsensitive(const QString &p_path)
     auto name = fi.fileName();
     int idx = 1;
     while (childExistsCaseInsensitive(dirPath, name)) {
-        name = QString("%1_%2").arg(baseName, QString::number(idx));
+        name = QStringLiteral("%1_%2").arg(baseName, QString::number(idx));
         if (!suffix.isEmpty()) {
             name += QStringLiteral(".") + suffix;
         }
@@ -213,7 +213,7 @@ void FileUtils::removeFile(const QString &p_filePath)
     QFile file(p_filePath);
     if (!file.remove()) {
         Exception::throwOne(Exception::Type::FailToRemoveFile,
-                            QString("failed to remove file: %1").arg(p_filePath));
+                            QStringLiteral("failed to remove file: %1").arg(p_filePath));
     }
 }
 
@@ -226,7 +226,7 @@ bool FileUtils::removeDirIfEmpty(const QString &p_dirPath)
 
     if (!dir.rmdir(p_dirPath)) {
         Exception::throwOne(Exception::Type::FailToRemoveFile,
-                            QString("failed to remove directory: %1").arg(p_dirPath));
+                            QStringLiteral("failed to remove directory: %1").arg(p_dirPath));
         return false;
     }
 
@@ -238,7 +238,7 @@ void FileUtils::removeDir(const QString &p_dirPath)
     QDir dir(p_dirPath);
     if (!dir.removeRecursively()) {
         Exception::throwOne(Exception::Type::FailToRemoveFile,
-                            QString("failed to remove directory recursively: %1").arg(p_dirPath));
+                            QStringLiteral("failed to remove directory recursively: %1").arg(p_dirPath));
     }
 }
 
@@ -302,7 +302,7 @@ QString FileUtils::generateUniqueFileName(const QString &p_folderPath,
     auto suffix = suffixIdx == -1 ? QStringLiteral("") : fileName.mid(suffixIdx);
     int index = 1;
     while (childExistsCaseInsensitive(p_folderPath, fileName)) {
-        fileName = QString("%1_%2%3").arg(baseName, QString::number(index++), suffix);
+        fileName = QStringLiteral("%1_%2%3").arg(baseName, QString::number(index++), suffix);
     }
 
     return fileName;
@@ -338,7 +338,7 @@ QString FileUtils::generateFileNameWithSequence(const QString &p_folderPath,
     auto suffix = p_suffix.isEmpty() ? QString() : QStringLiteral(".") + p_suffix;
     int index = 1;
     while (childExistsCaseInsensitive(p_folderPath, fileName)) {
-        fileName = QString("%1_%2%3").arg(p_baseName, QString::number(index++), suffix);
+        fileName = QStringLiteral("%1_%2%3").arg(p_baseName, QString::number(index++), suffix);
     }
 
     return fileName;

--- a/src/utils/htmlutils.cpp
+++ b/src/utils/htmlutils.cpp
@@ -22,7 +22,7 @@ QString HtmlUtils::unicodeEncode(const QString &p_text)
     QString encodedStr;
     for (const auto ch : p_text) {
         if (ch.unicode() > 255) {
-            encodedStr += QString("&#%1;").arg(static_cast<int>(ch.unicode()));
+            encodedStr += QStringLiteral("&#%1;").arg(static_cast<int>(ch.unicode()));
         } else {
             encodedStr += ch;
         }

--- a/src/utils/iconutils.cpp
+++ b/src/utils/iconutils.cpp
@@ -70,7 +70,7 @@ QString IconUtils::replaceForegroundOfIcon(const QString &p_iconContent, const Q
     QRegularExpression styleRe(R"((\s|"|;)(fill|stroke)(:|(="))(?!none)[^;"]*)");
     if (p_iconContent.indexOf(styleRe) > -1) {
         auto newContent(p_iconContent);
-        newContent.replace(styleRe, QString("\\1\\2\\3%1").arg(p_foreground));
+        newContent.replace(styleRe, QStringLiteral("\\1\\2\\3%1").arg(p_foreground));
         return newContent;
     }
 

--- a/src/utils/pathutils.cpp
+++ b/src/utils/pathutils.cpp
@@ -7,7 +7,7 @@
 
 using namespace vnotex;
 
-const QString PathUtils::c_fileNameRegularExpression = QString("\\A(?:[^\\\\/:\\*\\?\"<>\\|\\s]| )+\\z");
+const QString PathUtils::c_fileNameRegularExpression = QStringLiteral("\\A(?:[^\\\\/:\\*\\?\"<>\\|\\s]| )+\\z");
 
 QString PathUtils::parentDirPath(const QString &p_path)
 {

--- a/src/utils/webutils.cpp
+++ b/src/utils/webutils.cpp
@@ -46,7 +46,7 @@ QString WebUtils::toDataUri(const QUrl &p_url, bool p_keepTitle)
     }
 
     if (suffix == "svg") {
-        uri = QString("data:image/svg+xml;utf8,%1").arg(QString::fromUtf8(data));
+        uri = QStringLiteral("data:image/svg+xml;utf8,%1").arg(QString::fromUtf8(data));
         uri.replace('\r', "").replace('\n', "");
 
         // Using unescaped '#' characters in a data URI body is deprecated and
@@ -63,7 +63,7 @@ QString WebUtils::toDataUri(const QUrl &p_url, bool p_keepTitle)
             uri.remove(reg);
         }
     } else {
-        uri = QString("data:image/%1;base64,%2").arg(suffix, QString::fromUtf8(data.toBase64()));
+        uri = QStringLiteral("data:image/%1;base64,%2").arg(suffix, QString::fromUtf8(data.toBase64()));
     }
 
     return uri;

--- a/src/utils/widgetutils.cpp
+++ b/src/utils/widgetutils.cpp
@@ -215,7 +215,7 @@ void WidgetUtils::addActionShortcut(QAction *p_action,
 
     p_action->setShortcut(kseq);
     p_action->setShortcutContext(p_context);
-    p_action->setText(QString("%1\t%2").arg(p_action->text(), kseq.toString(QKeySequence::NativeText)));
+    p_action->setText(QStringLiteral("%1\t%2").arg(p_action->text(), kseq.toString(QKeySequence::NativeText)));
 }
 
 void WidgetUtils::addActionShortcutText(QAction *p_action, const QString &p_shortcut)
@@ -229,7 +229,7 @@ void WidgetUtils::addActionShortcutText(QAction *p_action, const QString &p_shor
         return;
     }
 
-    p_action->setText(QString("%1\t%2").arg(p_action->text(), kseq.toString(QKeySequence::NativeText)));
+    p_action->setText(QStringLiteral("%1\t%2").arg(p_action->text(), kseq.toString(QKeySequence::NativeText)));
 }
 
 void WidgetUtils::addButtonShortcutText(QPushButton *p_button, const QString &p_shortcut)
@@ -243,7 +243,7 @@ void WidgetUtils::addButtonShortcutText(QPushButton *p_button, const QString &p_
         return;
     }
 
-    p_button->setText(QString("%1 (%2)").arg(p_button->text(), kseq.toString(QKeySequence::NativeText)));
+    p_button->setText(QStringLiteral("%1 (%2)").arg(p_button->text(), kseq.toString(QKeySequence::NativeText)));
 }
 
 void WidgetUtils::updateSize(QWidget *p_widget)

--- a/src/widgets/dialogs/exportdialog.cpp
+++ b/src/widgets/dialogs/exportdialog.cpp
@@ -879,7 +879,7 @@ void ExportDialog::updatePageLayoutButtonLabel()
 {
     Q_ASSERT(m_pageLayout);
     m_pageLayoutBtn->setText(
-        QString("%1, %2").arg(m_pageLayout->pageSize().name(),
+        QStringLiteral("%1, %2").arg(m_pageLayout->pageSize().name(),
                               m_pageLayout->orientation() == QPageLayout::Portrait ? tr("Portrait") : tr("Landscape")));
 }
 

--- a/src/widgets/dialogs/settings/generalpage.cpp
+++ b/src/widgets/dialogs/settings/generalpage.cpp
@@ -29,7 +29,7 @@ void GeneralPage::setupUI()
         m_localeComboBox->addItem(tr("Default"), QString());
         for (const auto &loc : ConfigMgr::getInst().getCoreConfig().getAvailableLocales()) {
             QLocale locale(loc);
-            m_localeComboBox->addItem(QString("%1 (%2)").arg(locale.nativeLanguageName(), locale.nativeCountryName()),
+            m_localeComboBox->addItem(QStringLiteral("%1 (%2)").arg(locale.nativeLanguageName(), locale.nativeCountryName()),
                                       loc);
         }
 

--- a/src/widgets/dockwidgethelper.cpp
+++ b/src/widgets/dockwidgethelper.cpp
@@ -330,7 +330,7 @@ void DockWidgetHelper::setupDockActivateShortcut(QDockWidget *p_dock, const QStr
 {
     auto shortcut = WidgetUtils::createShortcut(p_keys, m_mainWindow);
     if (shortcut) {
-        p_dock->setToolTip(QString("%1\t%2").arg(p_dock->windowTitle(),
+        p_dock->setToolTip(QStringLiteral("%1\t%2").arg(p_dock->windowTitle(),
                                                  QKeySequence(p_keys).toString(QKeySequence::NativeText)));
         connect(shortcut, &QShortcut::activated,
                 this, [this, p_dock]() {

--- a/src/widgets/editors/graphvizhelper.cpp
+++ b/src/widgets/editors/graphvizhelper.cpp
@@ -64,7 +64,7 @@ QPair<bool, QString> GraphvizHelper::testGraphviz(const QString &p_graphvizFile)
                                      errData);
     ret.first = (state == ProcessUtils::Succeeded) && (exitCode == 0);
 
-    ret.second = QString("%1 %2\n\nExitcode: %3\n\nOutput: %4\n\nError: %5")
+    ret.second = QStringLiteral("%1 %2\n\nExitcode: %3\n\nOutput: %4\n\nError: %5")
                         .arg(program, args.join(' '), QString::number(exitCode), QString::fromLocal8Bit(outData), QString::fromLocal8Bit(errData));
 
     return ret;

--- a/src/widgets/editors/markdowneditor.cpp
+++ b/src/widgets/editors/markdowneditor.cpp
@@ -1323,7 +1323,7 @@ void MarkdownEditor::fetchImagesToLocalAndReplace(QString &p_text)
         }
 
         // Replace URL in link.
-        QString newLink = QString("![%1](%2%3%4)")
+        QString newLink = QStringLiteral("![%1](%2%3%4)")
                                  .arg(imageTitle, urlInLink, match.captured(3), match.captured(6));
         p_text.replace(reg.m_startPos,
                        reg.m_endPos - reg.m_startPos,

--- a/src/widgets/editors/markdowntable.cpp
+++ b/src/widgets/editors/markdowntable.cpp
@@ -31,12 +31,12 @@ QString MarkdownTable::Row::toString() const
 {
     QString cells;
     for (auto & cell : m_cells) {
-        cells += QString(" (%1, %2 [%3])").arg(cell.m_offset)
+        cells += QStringLiteral(" (%1, %2 [%3])").arg(cell.m_offset)
                                          .arg(cell.m_length)
                                          .arg(cell.m_text);
     }
 
-    return QString("row %1 %2").arg(m_block.blockNumber()).arg(cells);
+    return QStringLiteral("row %1 %2").arg(m_block.blockNumber()).arg(cells);
 }
 
 qreal MarkdownTable::s_spaceWidth = -1;
@@ -585,7 +585,7 @@ QString MarkdownTable::generateFormattedText(const QString &p_core,
         rightSpaces = 0;
     }
 
-    return QString("%1 %2%3%4 ").arg(c_borderChar,
+    return QStringLiteral("%1 %2%3%4 ").arg(c_borderChar,
                                      QString(leftSpaces, ' '),
                                      p_core,
                                      QString(rightSpaces, ' '));

--- a/src/widgets/editors/plantumlhelper.cpp
+++ b/src/widgets/editors/plantumlhelper.cpp
@@ -97,7 +97,7 @@ QPair<bool, QString> PlantUmlHelper::testPlantUml(const QString &p_plantUmlJarFi
                                      errData);
     ret.first = (state == ProcessUtils::Succeeded) && (exitCode == 0);
 
-    ret.second = QString("%1 %2\n\nExitcode: %3\n\nOutput: %4\n\nError: %5")
+    ret.second = QStringLiteral("%1 %2\n\nExitcode: %3\n\nOutput: %4\n\nError: %5")
                         .arg(program, args.join(' '), QString::number(exitCode), QString::fromLocal8Bit(outData), QString::fromLocal8Bit(errData));
 
     return ret;

--- a/src/widgets/mainwindow.cpp
+++ b/src/widgets/mainwindow.cpp
@@ -537,7 +537,7 @@ QString MainWindow::getViewAreaTitle() const
     if (win) {
         title = win->getName();
     }
-    return title.isEmpty() ? QString() : QString("%1 - %2").arg(title, ConfigMgr::c_appName);
+    return title.isEmpty() ? QString() : QStringLiteral("%1 - %2").arg(title, ConfigMgr::c_appName);
 }
 
 void MainWindow::setupOutlineViewer()

--- a/src/widgets/markdownviewwindow.cpp
+++ b/src/widgets/markdownviewwindow.cpp
@@ -1066,7 +1066,7 @@ void MarkdownViewWindow::handleFileOpenParameters(const QSharedPointer<FileOpenP
         Q_ASSERT(!isReadMode());
         const auto &markdownEditorConfig = ConfigMgr::getInst().getEditorConfig().getMarkdownEditorConfig();
         if (markdownEditorConfig.getInsertFileNameAsTitle() && buffer->getContent().isEmpty()) {
-            const auto title = QString("# %1\n").arg(QFileInfo(buffer->getName()).completeBaseName());
+            const auto title = QStringLiteral("# %1\n").arg(QFileInfo(buffer->getName()).completeBaseName());
             m_editor->insertText(title);
         }
     } else {
@@ -1215,7 +1215,7 @@ void MarkdownViewWindow::removeFromImageHost(const QString &p_url)
 
     if (!ret) {
         MessageBoxHelper::notify(MessageBoxHelper::Warning,
-                                 QString("Failed to delete image (%1) from image host (%2).").arg(p_url, host->getName()),
+                                 QStringLiteral("Failed to delete image (%1) from image host (%2).").arg(p_url, host->getName()),
                                  QString(),
                                  errMsg,
                                  this);

--- a/src/widgets/navigationmode.cpp
+++ b/src/widgets/navigationmode.cpp
@@ -83,7 +83,7 @@ static QString generateNavigationLabelStyle(const QString &p_str, bool p_tiny)
     QColor bg(themeMgr.paletteColor(QStringLiteral("widgets#navigationlabel#bg")));
     bg.setAlpha(200);
 
-    QString style = QString("background-color: %1;"
+    QString style = QStringLiteral("background-color: %1;"
                             "color: %2;"
                             "font-size: %3pt;"
                             "font: bold;"
@@ -98,7 +98,7 @@ static QString generateNavigationLabelStyle(const QString &p_str, bool p_tiny)
                            .arg(pxWidth);
 
     if (p_tiny) {
-        style += QString("margin: 0px;"
+        style += QStringLiteral("margin: 0px;"
                          "padding: 0px;"
                          "min-height: %1px;"
                          "max-height: %1px;").arg(pxHeight);

--- a/src/widgets/notebooknodeexplorer.cpp
+++ b/src/widgets/notebooknodeexplorer.cpp
@@ -1493,7 +1493,7 @@ static QSharedPointer<Node> getNodeFromClipboardDataItem(const NodeClipboardData
     auto notebook = VNoteX::getInst().getNotebookMgr().findNotebookById(p_item->m_notebookId);
     if (!notebook) {
         Exception::throwOne(Exception::Type::InvalidArgument,
-                            QString("failed to find notebook by ID (%1)").arg(p_item->m_notebookId));
+                            QStringLiteral("failed to find notebook by ID (%1)").arg(p_item->m_notebookId));
         return nullptr;
     }
 

--- a/src/widgets/viewwindowtoolbarhelper.cpp
+++ b/src/widgets/viewwindowtoolbarhelper.cpp
@@ -57,7 +57,7 @@ void ViewWindowToolBarHelper::addActionShortcut(QAction *p_action,
                      p_action, [p_action]() {
                          qWarning() << "ViewWindow shortcut activated ambiguously" << p_action->text();
                      });
-    p_action->setText(QString("%1\t%2").arg(p_action->text(), shortcut->key().toString(QKeySequence::NativeText)));
+    p_action->setText(QStringLiteral("%1\t%2").arg(p_action->text(), shortcut->key().toString(QKeySequence::NativeText)));
 }
 
 void ViewWindowToolBarHelper::addButtonShortcut(QToolButton *p_btn,
@@ -77,9 +77,9 @@ void ViewWindowToolBarHelper::addButtonShortcut(QToolButton *p_btn,
                      });
     auto act = p_btn->defaultAction();
     if (act) {
-        act->setText(QString("%1\t%2").arg(act->text(), shortcut->key().toString(QKeySequence::NativeText)));
+        act->setText(QStringLiteral("%1\t%2").arg(act->text(), shortcut->key().toString(QKeySequence::NativeText)));
     } else {
-        p_btn->setText(QString("%1\t%2").arg(p_btn->text(), shortcut->key().toString(QKeySequence::NativeText)));
+        p_btn->setText(QStringLiteral("%1\t%2").arg(p_btn->text(), shortcut->key().toString(QKeySequence::NativeText)));
     }
 }
 

--- a/tests/test_task/test_task.cpp
+++ b/tests/test_task/test_task.cpp
@@ -60,11 +60,11 @@ void TestTask::TestTaskVariableMgr()
     {
         const auto env = QProcessEnvironment::systemEnvironment();
         result = mgr.evaluate(task.data(), "${env:PATH} ${env:QT_PATH} ${env:nonexist}");
-        QCOMPARE(result, QString("%1 %2 %3").arg(env.value("PATH"), env.value("QT_PATH"), env.value("nonexist")));
+        QCOMPARE(result, QStringLiteral("%1 %2 %3").arg(env.value("PATH"), env.value("QT_PATH"), env.value("nonexist")));
     }
 
     result = mgr.evaluate(task.data(), "${config:main.core.toolbar_icon_size} ${config:main.core.nonexists} ${config:session.core.system_title_bar}");
-    QCOMPARE(result, QString("%1  %2").arg(ConfigMgr::getInst().getCoreConfig().getToolBarIconSize())
+    QCOMPARE(result, QStringLiteral("%1  %2").arg(ConfigMgr::getInst().getCoreConfig().getToolBarIconSize())
                                       .arg(ConfigMgr::getInst().getSessionConfig().getSystemTitleBarEnabled()));
 }
 


### PR DESCRIPTION
- Qt provides a macro [QStringLiteral()](https://doc.qt.io/qt-6/qstring.html#QStringLiteral), which makes constructing QString objects from string literals more efficient.