### PR TITLE
ci: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -135,7 +135,7 @@ jobs:
         working-directory: ${{runner.workspace}}/build
 
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: VNote-${{env.VNOTE_VER}}-linux-x64.AppImage
           path: ${{runner.workspace}}/build/VNote-${{env.VNOTE_VER}}-linux-x64.AppImage

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -119,7 +119,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: VNote-${{env.VNOTE_VER}}-mac-${{matrix.config.arch}}
           path: ${{runner.workspace}}/build/VNote-${{env.VNOTE_VER}}-mac-${{matrix.config.arch}}.dmg

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -111,14 +111,14 @@ jobs:
         working-directory: ${{runner.workspace}}/build
 
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: VNote-${{env.VNOTE_VER}}-win64${{matrix.config.suffix}}
           path: ${{runner.workspace}}/build/VNote-${{env.VNOTE_VER}}-win64${{matrix.config.suffix}}
 
       - name: Archive Installer
         if: ${{!startsWith(matrix.config.qt, '5.15')}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: VNote-${{env.VNOTE_VER}}-win64${{matrix.config.suffix}}.msi
           path: ${{runner.workspace}}/build/VNote*.msi


### PR DESCRIPTION
- Update `actions/upload-artifact` to fix workflow failure.