### PR TITLE
tag search: add comboBox for searching

### DIFF
--- a/src/widgets/tagexplorer.h
+++ b/src/widgets/tagexplorer.h
@@ -4,6 +4,8 @@
 #include <QFrame>
 #include <QSharedPointer>
 #include <QScopedPointer>
+#include <QComboBox>
+
 
 #include "navigationmodewrapper.h"
 
@@ -39,6 +41,8 @@ namespace vnotex
         void handleTagTreeContextMenuRequested(const QPoint &p_pos);
 
         void handleTagMoved(QTreeWidgetItem *p_item);
+
+        void filterTags(const QString &p_text);
 
     private:
         enum Column { Name = 0 };
@@ -99,6 +103,8 @@ namespace vnotex
         QIcon m_tagIcon;
 
         QIcon m_nodeIcon;
+
+        QComboBox *m_tagSearchEdit = nullptr;
     };
 }
 


### PR DESCRIPTION
When there are numerous tags, it becomes difficult to quickly locate desired ones. Therefore, a search box is added for tag filtering.‌

 -  ‌When the search box is non-empty:‌ Hide tags whose names do not contain the search keyword.
 -  ‌When the search box is empty:‌ Show all tags (default state).

Please see：https://github.com/vnotex/vnote/issues/2627