### PR TITLE
【ErrorBranch】QuickAccess: change link address from hard link to '#signature'

### DIFF
--- a/src/widgets/notebooknodeexplorer.cpp
+++ b/src/widgets/notebooknodeexplorer.cpp
@@ -6,6 +6,8 @@
 #include <QAction>
 #include <QSet>
 #include <QShortcut>
+#include <QJsonObject>
+#include <QJsonParseError>
 
 #include <notebook/notebook.h>
 #include <notebook/node.h>
@@ -1348,14 +1350,66 @@ QAction *NotebookNodeExplorer::createAction(Action p_act, QObject *p_parent, boo
                 this, [this, p_master]() {
                     auto nodes = p_master ? getMasterSelectedNodesAndExternalNodes() : getSlaveSelectedNodesAndExternalNodes();
                     QStringList files;
+                    QStringList quick_infos;
                     for (const auto &node : nodes.first) {
                         files.push_back(node->fetchAbsolutePath());
                     }
                     for (const auto &node : nodes.second) {
                         files.push_back(node->fetchAbsolutePath());
                     }
+                    // get file signature
+                    for (const auto &file : files) {
+                        QString vxJsonPath;
+                        QString currentFileName;
+
+                        QFileInfo fileInfo(file);
+                        if (fileInfo.isFile()) {
+                            QString dirPath = PathUtils::parentDirPath(file);
+                            vxJsonPath = dirPath + "/vx.json";
+                            currentFileName = PathUtils::fileName(file);
+                        } else if (fileInfo.isDir()) {
+                            vxJsonPath = file + "/vx.json";
+                            currentFileName = PathUtils::fileName(file);
+                        } else {
+                            continue;
+                        }
+
+                        QFile vxFile(vxJsonPath);
+                        if (!vxFile.open(QIODevice::ReadOnly)) {
+                           continue;
+                        }
+                        QByteArray data = vxFile.readAll();
+                        vxFile.close();
+                        QJsonParseError parseError;
+                        QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
+                        if (parseError.error != QJsonParseError::NoError) {
+                            continue;
+                        }
+
+                        QJsonObject obj = doc.object();
+                        QString signature;
+
+                        if (obj.contains("files") && obj["files"].isArray()) {
+                            QJsonArray filesArray = obj["files"].toArray();
+                            for (const QJsonValue &fileVal : filesArray) {
+                                QJsonObject fileObj = fileVal.toObject();
+                                if (fileObj["name"].toString() == currentFileName) {
+                                    signature = fileObj["signature"].toString();
+                                    break;
+                                }
+                            }
+                        }
+                        if (signature.isEmpty() && obj.contains("signature")) {
+                            signature = obj["signature"].toString();
+                        }
+
+                        if (!signature.isEmpty()) {
+                            QString item = QString("#%1:%2").arg(signature, file);
+                            quick_infos.append(item);
+                        }
+                     }
                     if (!files.isEmpty()) {
-                        emit VNoteX::getInst().pinToQuickAccessRequested(files);
+                        emit VNoteX::getInst().pinToQuickAccessRequested(quick_infos);
                     }
                 });
         break;

--- a/src/widgets/toolbarhelper.cpp
+++ b/src/widgets/toolbarhelper.cpp
@@ -8,8 +8,11 @@
 #include <QDockWidget>
 #include <QApplication>
 #include <QDir>
+#include <QDirIterator>
 #include <QFileDialog>
 #include <QWidgetAction>
+#include <QJsonObject>
+#include <QJsonParseError>
 
 #include "mainwindow.h"
 #include <core/vnotex.h>
@@ -26,6 +29,7 @@
 #include <core/markdowneditorconfig.h>
 #include <core/fileopenparameters.h>
 #include <core/htmltemplatehelper.h>
+#include <core/notebookmgr.h>
 #include <core/exception.h>
 #include <task/taskmgr.h>
 #include <unitedentry/unitedentry.h>
@@ -493,7 +497,19 @@ void ToolBarHelper::updateQuickAccessMenu(QMenu *p_menu)
 
     for (const auto &file : quickAccess) {
         auto act = new QWidgetAction(p_menu);
-        auto widget = new LabelWithButtonsWidget(PathUtils::fileName(file), LabelWithButtonsWidget::Delete);
+        QString displayName = PathUtils::fileName(file);
+        QString displayFullName = file;
+
+        // check if file is "#signature:fileFullName"
+        if (file.startsWith('#')) {
+            int colonPos = file.indexOf(':');
+            if (colonPos != -1) {
+                displayFullName = file.mid(colonPos + 1);
+                displayName = PathUtils::fileName(displayFullName);   // get 'fileName'
+            }
+        }
+
+        auto widget = new LabelWithButtonsWidget(displayName, LabelWithButtonsWidget::Delete);
         p_menu->connect(widget, &LabelWithButtonsWidget::triggered,
                         p_menu, [p_menu, act]() {
                             const auto qaFile = act->data().toString();
@@ -506,7 +522,7 @@ void ToolBarHelper::updateQuickAccessMenu(QMenu *p_menu)
         // @act will own @widget.
         act->setDefaultWidget(widget);
         act->setData(file);
-        act->setToolTip(file);
+        act->setToolTip(displayFullName);
 
         // Must call after setDefaultWidget().
         p_menu->addAction(act);
@@ -777,9 +793,88 @@ void ToolBarHelper::setupMenuButton(MainWindow *p_win, QToolBar *p_toolBar)
 
 void ToolBarHelper::activateQuickAccess(const QString &p_file)
 {
+    if (p_file.length() > 1 && p_file[0] == '#')
+    {
+        activateQuickAccessFromVxUrl(p_file);
+    }else
+    {
+        activateQuickAccessFilePath(p_file);
+    }
+}
+
+void ToolBarHelper::activateQuickAccessFilePath(const QString &p_file)
+{
     const auto &coreConfig = ConfigMgr::getInst().getCoreConfig();
     auto paras = QSharedPointer<FileOpenParameters>::create();
     paras->m_mode = coreConfig.getDefaultOpenMode();
 
     emit VNoteX::getInst().openFileRequested(p_file, paras);
+}
+
+void ToolBarHelper::activateQuickAccessFromVxUrl(const QString &p_vx_url)
+{
+    auto notebook = VNoteX::getInst().getNotebookMgr().getCurrentNotebook();
+    if (!notebook) {
+        return;
+    }
+
+    // get 'signature' from format '#signature:filename'
+    QString target_signature = p_vx_url;
+
+    if (target_signature.startsWith('#')) {
+        target_signature = target_signature.mid(1); // remove '#'
+        if (target_signature.contains(':')) {
+            target_signature = target_signature.split(':').first(); // get 'signature'
+        }
+    }
+
+    // find signature in all vx.json file
+    const QString rootPath = notebook->getRootFolderAbsolutePath();
+    QDirIterator it(rootPath, {"vx.json"}, QDir::Files | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+    QStringList matchedFiles;
+
+    while (it.hasNext()) {
+        const QString vxPath = it.next();
+        QFile vxFile(vxPath);
+        if (!vxFile.open(QIODevice::ReadOnly)) {
+            continue;
+        }
+
+        const QJsonObject json = QJsonDocument::fromJson(vxFile.readAll()).object();
+        // find signature in files array
+        QString signature;
+        QString fileName;
+        const auto filesArray = json.value("files").toArray();
+        for (const auto &fileItem : filesArray) {
+            const auto fileObj = fileItem.toObject();
+            if (fileObj["signature"].toString() == target_signature) {
+                fileName = fileObj["name"].toString();
+                signature = target_signature;
+                break;
+            }
+        }
+        // if not find in files array, use directory signature
+        if (signature.isEmpty()) {
+            signature = json.value("signature").toString();
+        }
+
+        if (!signature.isEmpty() && signature == target_signature) {
+            const QString fullPath = PathUtils::concatenateFilePath(QFileInfo(vxPath).absolutePath(), fileName);
+            matchedFiles.append(fullPath);
+        }
+    }
+
+    // open matched files
+    const auto &coreConfig = ConfigMgr::getInst().getCoreConfig();
+    auto paras = QSharedPointer<FileOpenParameters>::create();
+    paras->m_mode = coreConfig.getDefaultOpenMode();
+
+    if (matchedFiles.isEmpty()) {
+        return;
+    }
+
+    for (const auto &file : matchedFiles) {
+        emit VNoteX::getInst().openFileRequested(file, paras);
+    }
+
 }

--- a/src/widgets/toolbarhelper.h
+++ b/src/widgets/toolbarhelper.h
@@ -49,6 +49,11 @@ namespace vnotex
         static void setupMenuButton(MainWindow *p_win, QToolBar *p_toolBar);
 
         static void activateQuickAccess(const QString &p_file);
+
+        static void activateQuickAccessFilePath(const QString &p_file);
+
+        static void activateQuickAccessFromVxUrl(const QString &p_vx_url);
+
     };
 } // ns vnotex
 

--- a/src/widgets/viewsplit.cpp
+++ b/src/widgets/viewsplit.cpp
@@ -11,6 +11,8 @@
 #include <QFileInfo>
 #include <QShortcut>
 #include <QActionGroup>
+#include <QJsonObject>
+#include <QJsonParseError>
 
 #include "viewwindow.h"
 #include "viewarea.h"
@@ -662,8 +664,44 @@ void ViewSplit::createContextMenuOnTabBar(QMenu *p_menu, int p_tabIdx)
                       [this, p_tabIdx]() {
                           auto win = getViewWindow(p_tabIdx);
                           if (win) {
-                              const QStringList files(win->getBuffer()->getPath());
-                              emit VNoteX::getInst().pinToQuickAccessRequested(files);
+                              // get file'signature' from vx.json
+                              const QString filePath = win->getBuffer()->getPath();
+                              QString dirPath = PathUtils::parentDirPath(filePath);
+                              QString vxJsonPath = dirPath + "/vx.json";
+                              QString currentFileName;
+
+                              QFile vxFile(vxJsonPath);
+                              if (!vxFile.open(QIODevice::ReadOnly)) {
+                                  return;
+                              }
+                              QByteArray data = vxFile.readAll();
+                              vxFile.close();
+                              QJsonParseError parseError;
+                              QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
+                              if (parseError.error != QJsonParseError::NoError) {
+                                  return;
+                              }
+
+                              QJsonObject obj = doc.object();
+                              QString signature;
+
+                              if (obj.contains("files") && obj["files"].isArray()) {
+                                  QJsonArray filesArray = obj["files"].toArray();
+                                  currentFileName = win->getBuffer()->getName();
+                                  for (const QJsonValue &fileVal : filesArray) {
+                                      QJsonObject fileObj = fileVal.toObject();
+                                      if (fileObj["name"].toString() == currentFileName) {
+                                          signature = fileObj["signature"].toString();
+                                          break;
+                                      }
+                                  }
+                              }
+
+                              if (!signature.isEmpty()) {
+                                  QString quickAccessItem = QString("#%1:%2").arg(signature, filePath);
+                                  const QStringList files(quickAccessItem);
+                                  emit VNoteX::getInst().pinToQuickAccessRequested(files);
+                              }
                           }
                       });
 


### PR DESCRIPTION
Use the format '#signature:fileName' for QuickAccess instead of absolute file paths (though compatibility support for absolute paths is still maintained).

Now each record in QuickAccess dynamically retrieves its absolute address when opened, which helps prevent broken links caused by file renaming or moving.

https://github.com/vnotex/vnote/issues/2636