### PR TITLE
VxUrlUtils: correct the behavior of 'getFilePath..' functions

### DIFF
--- a/src/utils/vxurlutils.h
+++ b/src/utils/vxurlutils.h
@@ -21,6 +21,9 @@ namespace vnotex
         // Get signature from vxUrl.
         static QString getSignatureFromVxURL(const QString &p_vxUrl);
 
+        // Get file name from vxUrl.
+        static QString getFileNameFromVxURL(const QString &p_vxUrl);
+
         // Get file path from vxUrl.
         static QString getFilePathFromVxURL(const QString &p_vxUrl);
 


### PR DESCRIPTION
1.Now, QWidgetAction in 'ToolBarHelper::updateQuickAccessMenu' functions properly with 'setToolTip(displayFullName);'

2.Skips vx.json files in the recycle bin directory when searching for signature.
