### PR TITLE
QuickAccess: correct VxUrl when accessing or changing files

### DIFF
--- a/src/utils/vxurlutils.h
+++ b/src/utils/vxurlutils.h
@@ -21,6 +21,9 @@ namespace vnotex
         // Get signature from vxUrl.
         static QString getSignatureFromVxURL(const QString &p_vxUrl);
 
+        // Get file name from vxUrl.
+        static QString getFileNameFromVxURL(const QString &p_vxUrl);
+
         // Get file path from vxUrl.
         static QString getFilePathFromVxURL(const QString &p_vxUrl);
 


### PR DESCRIPTION
Ensure that the path is always displayed correctly when the QuickAccess list is modified or read, fixing display inconsistencies caused by outdated VxUrl paths.