### PR TITLE
QuickAccess: update VxUrl list when accessing or changing entries

### DIFF
--- a/src/core/quickaccesshelper.cpp
+++ b/src/core/quickaccesshelper.cpp
@@ -12,6 +12,7 @@ void QuickAccessHelper::pinToQuickAccess(const QStringList &p_files)
     }
 
     auto &sessionConfig = ConfigMgr::getInst().getSessionConfig();
+    sessionConfig.tryCorrectQuickAccessFiles();
     auto qaFiles = sessionConfig.getQuickAccessFiles();
     qaFiles.append(p_files);
     qaFiles.removeDuplicates();

--- a/src/core/sessionconfig.h
+++ b/src/core/sessionconfig.h
@@ -159,6 +159,7 @@ namespace vnotex
         void setQuickAccessFiles(const QStringList &p_files);
 
         void removeQuickAccessFile(const QString &p_file);
+        bool tryCorrectQuickAccessFiles(void);
 
         const QVector<ExternalProgram> &getExternalPrograms() const;
         const ExternalProgram *findExternalProgram(const QString &p_name) const;

--- a/src/widgets/toolbarhelper.cpp
+++ b/src/widgets/toolbarhelper.cpp
@@ -486,7 +486,10 @@ void ToolBarHelper::addSpacer(QToolBar *p_toolBar)
 void ToolBarHelper::updateQuickAccessMenu(QMenu *p_menu)
 {
     p_menu->clear();
-    const auto &quickAccess = ConfigMgr::getInst().getSessionConfig().getQuickAccessFiles();
+    auto &sessionConfig = ConfigMgr::getInst().getSessionConfig();
+    sessionConfig.tryCorrectQuickAccessFiles();
+
+    const auto &quickAccess = sessionConfig.getQuickAccessFiles();
     if (quickAccess.isEmpty()) {
         auto act = p_menu->addAction(MainWindow::tr("Quick Access Not Set"));
         act->setEnabled(false);


### PR DESCRIPTION
Ensure that the path is always displayed correctly when the QuickAccess list is
modified or read, to fix display inconsistencies caused by outdated VxUrl paths.