### PR TITLE
MarkdownEditor : Copy local GIF to clipboard without frame loss

### DIFF
--- a/src/utils/clipboardutils.cpp
+++ b/src/utils/clipboardutils.cpp
@@ -11,6 +11,7 @@
 
 #include "utils.h"
 #include "pathutils.h"
+#include "fileutils.h"
 
 using namespace vnotex;
 
@@ -186,6 +187,7 @@ void ClipboardUtils::setImageToClipboard(QClipboard *p_clipboard,
 #endif
 }
 
+
 void ClipboardUtils::setImageLoop(QClipboard *p_clipboard,
                                   const QImage &p_image,
                                   QClipboard::Mode p_mode)
@@ -219,4 +221,17 @@ std::unique_ptr<QMimeData> ClipboardUtils::linkMimeData(const QString &p_link)
 
     data->setText(text);
     return data;
+}
+
+void ClipboardUtils::setLocalFileToClipboard(QClipboard *p_clipboard,
+                                            const QString &p_filePath,
+                                            QClipboard::Mode p_mode)
+{
+    // Check if the file exists
+    if (!FileUtils::existsCaseInsensitive(p_filePath)) {
+        qWarning() << "ClipboardUtils::setLocalFileToClipboard: file does not exist:" << p_filePath;
+        return;
+    }
+
+    setMimeDataToClipboard(p_clipboard, linkMimeData(p_filePath).release(), p_mode);
 }

--- a/src/utils/clipboardutils.h
+++ b/src/utils/clipboardutils.h
@@ -31,6 +31,11 @@ namespace vnotex
                                         const QImage &p_image,
                                         QClipboard::Mode p_mode = QClipboard::Clipboard);
 
+        // Set a local file to clipboard.
+        static void setLocalFileToClipboard(QClipboard *p_clipboard,
+                                            const QString &p_filePath,
+                                            QClipboard::Mode p_mode = QClipboard::Clipboard);
+
     private:
         static bool mimeDataEquals(const QMimeData *p_a, const QMimeData *p_b);
 

--- a/src/widgets/editors/markdowneditor.cpp
+++ b/src/widgets/editors/markdowneditor.cpp
@@ -1677,6 +1677,12 @@ bool MarkdownEditor::prependImageMenu(QMenu *p_menu, QAction *p_before, int p_cu
                     auto clipboard = QApplication::clipboard();
                     clipboard->clear();
 
+                    // Copy local GIF to clipboard to ensure no frame loss
+                    if (imgPath.endsWith(QStringLiteral(".gif"), Qt::CaseInsensitive) && FileUtils::existsCaseInsensitive(imgPath)) {
+                        ClipboardUtils::setLocalFileToClipboard(clipboard, imgPath, QClipboard::Clipboard);
+                        return ;
+                    }
+
                     auto img = FileUtils::imageFromFile(imgPath);
                     if (!img.isNull()) {
                         ClipboardUtils::setImageToClipboard(clipboard, img);


### PR DESCRIPTION
Given that GIF images are converted to static images by QImage in the existing 'Copy Image' processing, while lossless pasting can be achieved through copying files, special handling is therefore applied to local GIFs during 'Copy Image'.1. 

(After attempting to change QImage to QMovie, which would involve more complicated modifications, this workaround was adopted.)

https://github.com/vnotex/vnote/issues/2491