### PR TITLE
Reach the standard context menu through the API each Qt major has

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -1,5 +1,6 @@
 #include "utils.h"
 
+#include <QCoreApplication>
 #include <QDebug>
 #include <QDir>
 #include <QElapsedTimer>

--- a/src/widgets/commentpanel.cpp
+++ b/src/widgets/commentpanel.cpp
@@ -1,6 +1,10 @@
 #include "commentpanel.h"
 
 #include <QComboBox>
+// Explicit: the free functions below call QCoreApplication::translate()
+// directly (they are not members, so tr() is unavailable). Qt 6's widget
+// headers happen to pull this in transitively; Qt 5.15's do not.
+#include <QCoreApplication>
 #include <QLabel>
 #include <QListWidget>
 #include <QPlainTextEdit>

--- a/src/widgets/editors/pdfviewer.cpp
+++ b/src/widgets/editors/pdfviewer.cpp
@@ -50,7 +50,19 @@ void PdfViewer::setSwatchResolver(CommentColorSwatch::ColorResolver p_resolve,
 }
 
 void PdfViewer::contextMenuEvent(QContextMenuEvent *p_event) {
+  // The standard menu moved between the two Qt majors VNote builds against, and
+  // neither spelling compiles on both: QWebEngineView::createStandardContextMenu()
+  // arrived in Qt 6.2, while QWebEnginePage's overload is gone in Qt 6.
+  //
+  // This class is only INSTANTIATED above Qt 6.9 (ViewWindowFactory registers
+  // the PDF creator conditionally), but it is always COMPILED -- which is why
+  // the Qt 5.15 / Windows 7 packaging job broke here while every Qt 6 job stayed
+  // green. See .github/AGENTS.md.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
   QScopedPointer<QMenu> menu(createStandardContextMenu());
+#else
+  QScopedPointer<QMenu> menu(page()->createStandardContextMenu());
+#endif
   if (!menu) {
     menu.reset(new QMenu(this));
   }


### PR DESCRIPTION
## Problem

The **Win64 Qt 5.15** job has been failing to compile, on `master`, before and after the latest pushes:

```
src\widgets\editors\pdfviewer.cpp(53): error C3861: 'createStandardContextMenu': identifier not found
```

`QWebEngineView::createStandardContextMenu()` only arrived in **Qt 6.2**. The overload Qt 5 offers lives on `QWebEnginePage`, and that one is **gone in Qt 6** — so neither spelling compiles against both majors.

## Why only that job noticed

`PdfViewer` is only *instantiated* above Qt 6.9 (`ViewWindowFactory` registers the PDF creator conditionally), but it is always *compiled*. Every Qt 6 job therefore stayed green while the Windows 7 / Qt 5.15 packaging variant broke — exactly the split `.github/AGENTS.md` warns about.

## Fix

Select the API by Qt major at the one call site, with a comment recording why the guard exists so it is not "cleaned up" later.

## Verification

- Builds clean locally on Qt 6.10.3 / MSVC.
- Full suite: 228/228.
- The Qt 5.15 half is what this PR exists to prove; CI is the check.

No behaviour change on Qt 6.